### PR TITLE
Experimental Smart chunking

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Phlex::Context
-	def initialize
+	def initialize(buffer = +"")
+		@buffer = buffer
 		@target = +""
 	end
 
-	attr_accessor :target
+	attr_accessor :target, :buffer
 
 	def with_target(new_target)
 		original_target = @target

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class Phlex::Context
-	def initialize(buffer = +"")
-		@buffer = buffer
+	def initialize
 		@target = +""
 	end
 
-	attr_accessor :target, :buffer
+	attr_accessor :target
 
 	def with_target(new_target)
 		original_target = @target

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -34,7 +34,7 @@ module Phlex::Elements
 					end
 				end
 
-				#{'@_context.buffer << target; target.clear;' if tag == 'head'}
+				#{'flush' if tag == 'head'}
 
 				nil
 			end

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -13,7 +13,6 @@ module Phlex::Elements
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 
-
 			def #{element}(**attributes, &block)
 				target = @_context.target
 
@@ -34,6 +33,8 @@ module Phlex::Elements
 						target << "<#{tag}></#{tag}>"
 					end
 				end
+
+				#{'@_context.buffer << target; target.clear;' if tag == 'head'}
 
 				nil
 			end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -43,14 +43,14 @@ module Phlex
 		end
 
 		# Renders the view and returns the buffer. The default buffer is a mutable String.
-		def call(buffer = nil, context: Phlex::Context.new, view_context: nil, parent: nil, &block)
+		def call(buffer = +"", context: Phlex::Context.new(buffer), view_context: nil, parent: nil, &block)
 			__final_call__(buffer, context: context, view_context: view_context, parent: parent, &block).tap do
 				self.class.rendered_at_least_once!
 			end
 		end
 
 		# @api private
-		def __final_call__(buffer = nil, context: Phlex::Context.new, view_context: nil, parent: nil, &block)
+		def __final_call__(buffer = +"", context: Phlex::Context.new(buffer), view_context: nil, parent: nil, &block)
 			@_context = context
 			@_view_context = view_context
 			@_parent = parent
@@ -78,7 +78,7 @@ module Phlex
 				end
 			end
 
-			buffer ? (buffer << context.target) : context.target
+			buffer << context.target
 		end
 
 		# Render another view

--- a/test/phlex/view/call.rb
+++ b/test/phlex/view/call.rb
@@ -25,11 +25,6 @@ describe Phlex::HTML do
 				!@_view_context
 			end
 		end
-
-		it "returns buffer content" do
-			buffer = "xyz"
-			expect(example.call(buffer, view_context: true)).to be == "xyz"
-		end
 	end
 
 	with "a view that yields an object" do


### PR DESCRIPTION
This PR updates Phlex to write to the buffer after `</head>`. Additionally, it provides a `await` interface for waiting on asynchronous tasks. If the task is finished, it will continue rendering; otherwise, it will write to the buffer while waiting.

```ruby
class Articles < Phlex::HTML
  def initialize(articles_query)
    @articles_query = articles_query
  end

  def template
    h1 { "Articles" }

    ul(class: "articles")
      await(@articles_query).each do |article|
        li { article.title }
      end
    end
  end
end
```

In this example, if the `articles_query` isn't finished by the time we await it, we will write the following to the buffer while waiting for it to resolve.

```html
<h1>Articles</h1><ul class="articles">
```

The component can be invoked with an Async task like this:

```ruby
Sync do
  Articles.new(
    Async { some_slow_query }
  ).call(stream)
end
```

Or using Concurrent Ruby IVars. For example, if `SomeClass` includes `Concurrent::Async`, we could invoke the component like this.

```ruby
Articles.new(SomeClass.async.some_slow_query).call
```

In the future, this feature could be patched by phlex-rails to support asynchronous ActiveRecord queries, e.g.

```ruby
render ArticlesComponent.new(Article.all.load_async)
```