### PR TITLE
Raise when trying to output an unknown object using `plain`

### DIFF
--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -28,6 +28,7 @@ module Phlex::Elements
 	# Register a custom element. This macro defines an element method for the current class and descendents only. There is no global element registry.
 	# @param method_name [Symbol]
 	# @param tag [String] the name of the tag, otherwise this will be the method name with underscores replaced with dashes.
+	# @return [Symbol] the name of the method created
 	# @note The methods defined by this macro depend on other methods from {SGML} so they should always be mixed into an {HTML} or {SVG} component.
 	# @example Register the custom element `<trix-editor>`
 	# 	register_element :trix_editor

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -30,12 +30,6 @@ module Phlex
 			nil
 		end
 
-		# @deprecated use {#plain} instead.
-		def text(...)
-			warn "DEPRECATED: The `text` method has been deprecated in favour of `plain`. Please use `plain` instead. The `text` method will be removed in a future version of Phlex. Called from: #{caller.first}"
-			plain(...)
-		end
-
 		# Outputs an `<svg>` tag
 		# @return [nil]
 		# @see https://developer.mozilla.org/docs/Web/SVG/Element/svg

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -127,7 +127,7 @@ module Phlex
 		end
 
 		# Output text content. The text will be HTML-escaped.
-		# @param content [String, Symbol, Integer, void] the content to be output on the buffer. Strings, Symbols, and Integers are handled by <code>plain</code> directly, but any object can be handled by overriding <code>format_object</code>
+		# @param content [String, Symbol, Integer, void] the content to be output on the buffer. Strings, Symbols, and Integers are handled by `plain` directly, but any object can be handled by overriding `format_object`
 		# @return [nil]
 		# @see #format_object
 		def plain(content)
@@ -241,7 +241,7 @@ module Phlex
 			nil
 		end
 
-		# Determines if the component should render. By default, it returns <code>true</code>.
+		# Determines if the component should render. By default, it returns `true`.
 		# @abstract Override to define your own predicate to prevent rendering.
 		# @return [Boolean]
 		def render?
@@ -249,7 +249,7 @@ module Phlex
 		end
 
 		# Format the object for output
-		# @abstract Override to define your own format handling for different object types. Please remember to call <code>super</code> in the case that the passed object doesn't match, so that object formatting can be added at different layers of the inheritance tree.
+		# @abstract Override to define your own format handling for different object types. Please remember to call `super` in the case that the passed object doesn't match, so that object formatting can be added at different layers of the inheritance tree.
 		# @return [String]
 		def format_object(object)
 			case object
@@ -258,7 +258,7 @@ module Phlex
 			end
 		end
 
-		# @abstract Override this method to hook in around a template render. You can do things before and after calling <code>super</code> to render the template. You should always call <code>super</code> so that callbacks can be added at different layers of the inheritance tree.
+		# @abstract Override this method to hook in around a template render. You can do things before and after calling `super` to render the template. You should always call `super` so that callbacks can be added at different layers of the inheritance tree.
 		# @return [nil]
 		def around_template
 			before_template
@@ -268,13 +268,13 @@ module Phlex
 			nil
 		end
 
-		# @abstract Override this method to hook in right before a template is rendered. Please remember to call <code>super</code> so that callbacks can be added at different layers of the inheritance tree.
+		# @abstract Override this method to hook in right before a template is rendered. Please remember to call `super` so that callbacks can be added at different layers of the inheritance tree.
 		# @return [nil]
 		def before_template
 			nil
 		end
 
-		# @abstract Override this method to hook in right after a template is rendered. Please remember to call <code>super</code> so that callbacks can be added at different layers of the inheritance tree.
+		# @abstract Override this method to hook in right after a template is rendered. Please remember to call `super` so that callbacks can be added at different layers of the inheritance tree.
 		# @return [nil]
 		def after_template
 			nil

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -303,7 +303,7 @@ module Phlex
 
 			original_length = target.length
 			content = yield(self)
-			plain(content) if original_length == target.length
+			__text__(content) if original_length == target.length
 
 			nil
 		end
@@ -317,7 +317,7 @@ module Phlex
 
 			original_length = target.length
 			content = yield
-			plain(content) if original_length == target.length
+			__text__(content) if original_length == target.length
 
 			nil
 		end
@@ -332,7 +332,28 @@ module Phlex
 
 			original_length = target.length
 			content = yield(*args)
-			plain(content) if original_length == target.length
+			__text__(content) if original_length == target.length
+
+			nil
+		end
+
+		# Performs the same task as the public method #plain, but does not raise an error if an unformattable object is passed
+		# @api private
+		def __text__(content)
+			case content
+			when String
+				@_context.target << ERB::Escape.html_escape(content)
+			when Symbol
+				@_context.target << ERB::Escape.html_escape(content.name)
+			when Integer
+				@_context.target << ERB::Escape.html_escape(content.to_s)
+			when nil
+				nil
+			else
+				if (formatted_object = format_object(content))
+					@_context.target << ERB::Escape.html_escape(formatted_object)
+				end
+			end
 
 			nil
 		end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -131,21 +131,8 @@ module Phlex
 		# @return [nil]
 		# @see #format_object
 		def plain(content)
-			case content
-			when String
-				@_context.target << ERB::Escape.html_escape(content)
-			when Symbol
-				@_context.target << ERB::Escape.html_escape(content.name)
-			when Integer
-				@_context.target << ERB::Escape.html_escape(content.to_s)
-			when nil
-				nil
-			else
-				if (formatted_object = format_object(content))
-					@_context.target << ERB::Escape.html_escape(formatted_object)
-				else
-					raise ArgumentError, "You've passed an object to plain that is not handled by format_object. See https://rubydoc.info/gems/phlex/Phlex/SGML#format_object-instance_method for more information"
-				end
+			unless __text__(content)
+				raise ArgumentError, "You've passed an object to plain that is not handled by format_object. See https://rubydoc.info/gems/phlex/Phlex/SGML#format_object-instance_method for more information"
 			end
 
 			nil
@@ -352,10 +339,12 @@ module Phlex
 			else
 				if (formatted_object = format_object(content))
 					@_context.target << ERB::Escape.html_escape(formatted_object)
+				else
+					return false
 				end
 			end
 
-			nil
+			true
 		end
 
 		# @api private

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -127,7 +127,9 @@ module Phlex
 		end
 
 		# Output text content. The text will be HTML-escaped.
+		# @param content [String, Symbol, Integer, void] the content to be output on the buffer. Strings, Symbols, and Integers are handled by <code>plain</code> directly, but any object can be handled by overriding <code>format_object</code>
 		# @return [nil]
+		# @see #format_object
 		def plain(content)
 			case content
 			when String
@@ -141,6 +143,8 @@ module Phlex
 			else
 				if (formatted_object = format_object(content))
 					@_context.target << ERB::Escape.html_escape(formatted_object)
+				else
+					raise ArgumentError, "You've passed an object to plain that is not handled by format_object. See https://rubydoc.info/gems/phlex/Phlex/SGML#format_object-instance_method for more information"
 				end
 			end
 
@@ -258,6 +262,7 @@ module Phlex
 		end
 
 		# Format the object for output
+		# @abstract Override to define your own format handling for different object types. Please remember to call <code>super</code> in the case that the passed object doesn't match, so that object formatting can be added at different layers of the inheritance tree.
 		# @return [String]
 		def format_object(object)
 			case object

--- a/test/phlex/view/plain.rb
+++ b/test/phlex/view/plain.rb
@@ -3,19 +3,6 @@
 describe Phlex::HTML do
 	extend ViewHelper
 
-	with "deprecated text method" do
-		view do
-			def template
-				text "Depreacted"
-			end
-		end
-
-		it "renders content and prints deprecation warning" do
-			expect(example).to receive(:warn).with("DEPRECATED: The `text` method has been deprecated in favour of `plain`. Please use `plain` instead. The `text` method will be removed in a future version of Phlex. Called from: test/phlex/view/text.rb:9:in `template'")
-			expect(output).to be == "Depreacted"
-		end
-	end
-
 	with "text" do
 		view do
 			def template

--- a/test/phlex/view/text.rb
+++ b/test/phlex/view/text.rb
@@ -3,6 +3,19 @@
 describe Phlex::HTML do
 	extend ViewHelper
 
+	with "deprecated text method" do
+		view do
+			def template
+				text "Depreacted"
+			end
+		end
+
+		it "renders content and prints deprecation warning" do
+			expect(example).to receive(:warn).with("DEPRECATED: The `text` method has been deprecated in favour of `plain`. Please use `plain` instead. The `text` method will be removed in a future version of Phlex. Called from: test/phlex/view/text.rb:9:in `template'")
+			expect(output).to be == "Depreacted"
+		end
+	end
+
 	with "text" do
 		view do
 			def template
@@ -39,16 +52,15 @@ describe Phlex::HTML do
 		end
 	end
 
-	with "deprecated text method" do
+	with "an object that has no special format_object handling" do
 		view do
 			def template
-				text "Depreacted"
+				plain Object.new
 			end
 		end
 
-		it "renders content and prints deprecation warning" do
-			expect(example).to receive(:warn).with("DEPRECATED: The `text` method has been deprecated in favour of `plain`. Please use `plain` instead. The `text` method will be removed in a future version of Phlex. Called from: test/phlex/view/text.rb:45:in `template'")
-			expect(output).to be == "Depreacted"
+		it "raises an ArgumentError" do
+			expect { output }.to raise_exception(ArgumentError)
 		end
 	end
 end


### PR DESCRIPTION
The previous behavior was to output nothing, which might be unexpected, and could potentially go unnoticed. Now an `ArgumentError` will be raised along with an explanation of how to fix it:  which is to define your own `format_object` definition that knows how to convert the object to a string.

An implicit conversion to a string via `to_s` is being considered, but given that many objects in ruby implement `to_s` in a way that is not intended to be user facing, this could cause issues. Since the current behavior (of silently doing nothing) definitely seems wrong, we are starting with this as a first step. With a possible next step of coercing to a string via `to_s`.

I also moved the deprecated `text` test to the top of the file, because it does a check that involves the line number. I figured it might make the test more stable to move it to the top.

Closes #544, #518 