### PR TITLE
Support for Array and Set attribute values

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -397,12 +397,6 @@ module Phlex
 					buffer << " " << name << '="' << ERB::Escape.html_escape(v) << '"'
 				when Symbol
 					buffer << " " << name << '="' << ERB::Escape.html_escape(v.name) << '"'
-				when Array
-					if v.all? { |el| el.is_a?(String) || el.is_a?(Symbol) }
-						buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
-					else
-						raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"
-					end
 				when Hash
 					__build_attributes__(
 						v.transform_keys { |subkey|
@@ -412,6 +406,12 @@ module Phlex
 							end
 						}, buffer: buffer
 					)
+				when Array
+					if v.all? { |el| el.is_a?(String) || el.is_a?(Symbol) }
+						buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
+					else
+						raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"
+					end
 				else
 					raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"
 				end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -391,15 +391,19 @@ module Phlex
 				end
 
 				case v
-				in true
+				when true
 					buffer << " " << name
-				in String
+				when String
 					buffer << " " << name << '="' << ERB::Escape.html_escape(v) << '"'
-				in Symbol
+				when Symbol
 					buffer << " " << name << '="' << ERB::Escape.html_escape(v.name) << '"'
-				in Array => array if array.all? { |el| el.is_a?(String) || el.is_a?(Symbol) }
-					buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
-				in Hash
+				when Array
+					if v.all? { |el| el.is_a?(String) || el.is_a?(Symbol) }
+						buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
+					else
+						raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"
+					end
+				when Hash
 					__build_attributes__(
 						v.transform_keys { |subkey|
 							case subkey

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -407,11 +407,7 @@ module Phlex
 						}, buffer: buffer
 					)
 				when Array
-					if v.all? { |el| el.is_a?(String) || el.is_a?(Symbol) }
-						buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
-					else
-						raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"
-					end
+					buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
 				else
 					raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"
 				end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -406,8 +406,10 @@ module Phlex
 							end
 						}, buffer: buffer
 					)
-				when Array, Set
-					buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
+				when Array
+					buffer << " " << name << '="' << ERB::Escape.html_escape(v.compact.join(" ")) << '"'
+				when Set
+					buffer << " " << name << '="' << ERB::Escape.html_escape(v.to_a.compact.join(" ")) << '"'
 				else
 					raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"
 				end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -406,7 +406,7 @@ module Phlex
 							end
 						}, buffer: buffer
 					)
-				when Array
+				when Array, Set
 					buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
 				else
 					raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -391,13 +391,15 @@ module Phlex
 				end
 
 				case v
-				when true
+				in true
 					buffer << " " << name
-				when String
+				in String
 					buffer << " " << name << '="' << ERB::Escape.html_escape(v) << '"'
-				when Symbol
+				in Symbol
 					buffer << " " << name << '="' << ERB::Escape.html_escape(v.name) << '"'
-				when Hash
+				in Array => array if array.all? { |el| el.is_a?(String) || el.is_a?(Symbol) }
+					buffer << " " << name << '="' << ERB::Escape.html_escape(v.join(" ")) << '"'
+				in Hash
 					__build_attributes__(
 						v.transform_keys { |subkey|
 							case subkey
@@ -407,7 +409,7 @@ module Phlex
 						}, buffer: buffer
 					)
 				else
-					buffer << " " << name << '="' << ERB::Escape.html_escape(v.to_s) << '"'
+					raise ArgumentError, "Element attributes must be either a Boolean, a String, a Symbol, an Array of Strings or Symbols, or a Hash with values of one of these types"
 				end
 			end
 

--- a/test/phlex/view/attributes.rb
+++ b/test/phlex/view/attributes.rb
@@ -27,6 +27,66 @@ describe Phlex::HTML do
 		end
 	end
 
+	with "an array of string attributes" do
+		view do
+			def template
+				div(class: %w(bg-red-500 rounded))
+			end
+		end
+
+		it "joins the array with a space" do
+			expect(output).to be == %(<div class="bg-red-500 rounded"></div>)
+		end
+	end
+
+	with "an array of symbol attributes" do
+		view do
+			def template
+				div(class: %i(bg-red-500 rounded))
+			end
+		end
+
+		it "joins the array with a space" do
+			expect(output).to be == %(<div class="bg-red-500 rounded"></div>)
+		end
+	end
+
+	with "an array of symbol and string attributes" do
+		view do
+			def template
+				div(class: ["bg-red-500", :rounded])
+			end
+		end
+
+		it "joins the array with a space" do
+			expect(output).to be == %(<div class="bg-red-500 rounded"></div>)
+		end
+	end
+
+	with "an object that is not a boolean, String, Symbol, Array, or Hash" do
+		view do
+			def template
+				div(class: Object.new)
+			end
+		end
+
+		it "raises a Phlex::ArgumentError" do
+			expect { output }.to raise_exception(Phlex::ArgumentError)
+		end
+	end
+
+	with "an array that has an object that is not a boolean, String, Symbol, Array, or Hash" do
+		view do
+			def template
+				div(class: ["bg-red-500", :rounded, Object.new])
+			end
+		end
+
+		it "raises a Phlex::ArgumentError" do
+			expect { output }.to raise_exception(Phlex::ArgumentError)
+		end
+	end
+
 	if RUBY_ENGINE == "ruby"
 		with "unique tag attributes" do
 			view do

--- a/test/phlex/view/attributes.rb
+++ b/test/phlex/view/attributes.rb
@@ -63,6 +63,18 @@ describe Phlex::HTML do
 		end
 	end
 
+	with "a set of string attributes" do
+		view do
+			def template
+				div(class: Set["bg-red-500", "rounded"])
+			end
+		end
+
+		it "joins the array with a space" do
+			expect(output).to be == %(<div class="bg-red-500 rounded"></div>)
+		end
+	end
+
 	with "an object that is not a boolean, String, Symbol, Array, or Hash" do
 		view do
 			def template

--- a/test/phlex/view/attributes.rb
+++ b/test/phlex/view/attributes.rb
@@ -75,18 +75,6 @@ describe Phlex::HTML do
 		end
 	end
 
-	with "an array that has an object that is not a boolean, String, Symbol, Array, or Hash" do
-		view do
-			def template
-				div(class: ["bg-red-500", :rounded, Object.new])
-			end
-		end
-
-		it "raises a Phlex::ArgumentError" do
-			expect { output }.to raise_exception(Phlex::ArgumentError)
-		end
-	end
-
 	if RUBY_ENGINE == "ruby"
 		with "unique tag attributes" do
 			view do


### PR DESCRIPTION
This adds support for Array or Set attribute values like this:

```ruby
div(class: ["bg-red-500", "rounded"])
# or
div(class: Set["bg-red-500", "rounded"])
```

Array or Set attribute values will be treated like a token list, and its members will be joined with a space. This works as long as all elements are either strings or symbols.

Additionally, this change removes the implicit conversion of attribute values to a string by calling `to_s` on anything that is not recognized. Now attribute values that are not either a String, a Symbol, an Array, a Set, or a Hash with values of one of these types, will raise an ArgumentError.