### PR TITLE
[Proposal] Allowing component registration

### DIFF
--- a/lib/phlex/component_registrar.rb
+++ b/lib/phlex/component_registrar.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Phlex::ComponentRegistrar
+	def register_components(**components)
+		components.each do |helper_name, component_class|
+			define_method helper_name do |*args, **kwargs, &block|
+				render component_class.new(*args, **kwargs), &block
+			end
+		end
+	end
+end

--- a/test/phlex/component_registrar.rb
+++ b/test/phlex/component_registrar.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class LabelComponent < Phlex::HTML
+	def template(&block)
+		label(class: "text-md font-normal", &block)
+	end
+end
+
+describe Phlex::HTML do
+	extend ViewHelper
+
+	with "hooks" do
+		view do
+			extend Phlex::ComponentRegistrar
+
+			register_components label_component: LabelComponent
+
+			def template
+				label_component { "Password" }
+			end
+		end
+
+		it "allows component registration" do
+			expect(output).to be == '<label class="text-md font-normal">Password</label>'
+		end
+	end
+end


### PR DESCRIPTION
When using Phlex to create reusable components (eg. design system components), it's useful to have helpers for these components, avoiding the fully qualified name.
Instead:
```ruby
def template
  div do
    render Primer::Actions::ButtonComponent.new(...) do
      "Create"
    end
  end
end
```

We would have:
```ruby
def template
  div do
    primer_button(...) { "Create" }
  end
end
```

I had to code [my module](https://github.com/stephannv/stefin/blob/main/app/lib/ds/helpers.rb) to register components, this [polaris design system](https://github.com/baoagency/polaris_view_components/blob/main/app/helpers/polaris/view_helper.rb) is using a similar pattern (it's using ViewComponent but it demonstrate that component registration is a necessity), on my daily job we are using ViewComponent and we have to create our own component registrar too. So I think would be nice that Phlex have this feature built-in.

The idea is: 
1. User create a module
1. Extend `Phlex::ComponentRegistrar`
1. Register the components
1. Include the module where needed, eg. `ApplicationView`
```ruby
module ComponentHelpers
  extend Phlex::ComponentRegistrar
  
  register_components my_button: MyButton, my_label: MyLabel, my_tab: MyTab
end

class ApplicationComponent < Phlex::HTML
  include ComponentHelpers
end

class CardComponent < ApplicationComponent
  def template
    div class: "..." do
      my_label { "Label" }
      my_button(href: "#home") { "Home" }
      my_tab(href: "#contact") { "Contact" }
    end
  end
end
```
