### PR TITLE
Raise for keys that aren't Strings or Symbols

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -382,7 +382,7 @@ module Phlex
 				name = case k
 					when String then k
 					when Symbol then k.name.tr("_", "-")
-					else k.to_s
+					else raise ArgumentError, "Attribute keys should be Strings or Symbols."
 				end
 
 				# Detect unsafe attribute names. Attribute names are considered unsafe if they match an event attribute or include unsafe characters.


### PR DESCRIPTION
I can't think of a good reason to fall back to `to_s` here, so I think we should raise an error instead.

Closes #549 