### PR TITLE
`flush` during `capture`

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -182,7 +182,20 @@ module Phlex
 		def capture(&block)
 			return "" unless block
 
-			@_context.with_target(+"") { yield_content(&block) }
+			new_buffer = +""
+
+			begin
+				original_buffer = @_buffer
+				@_buffer = new_buffer
+				@_context.with_target(+"") do
+					yield_content(&block)
+					flush
+				end
+			ensure
+				@_buffer = original_buffer
+			end
+
+			new_buffer
 		end
 
 		private

--- a/test/phlex/view/capture.rb
+++ b/test/phlex/view/capture.rb
@@ -38,4 +38,25 @@ describe Phlex::HTML do
 			expect(example.captured).to be == "<h1>Hello</h1>"
 		end
 	end
+
+	with "a call to flush inside the block" do
+		view do
+			attr_accessor :captured
+
+			def template
+				h1 { "Before" }
+				@captured = capture do
+					h1 { "Hello" }
+					flush
+					h1 { "World" }
+				end
+				h1 { "After" }
+			end
+		end
+
+		it "should still contain the full capture" do
+			expect(example.call).to be == "<h1>Before</h1><h1>After</h1>"
+			expect(example.captured).to be == "<h1>Hello</h1><h1>World</h1>"
+		end
+	end
 end


### PR DESCRIPTION
If you issue a `flush` while inside of a `capture` block, the flush will happen to the calling component's buffer and not to the string being captured.

This fixes the issue by not only changing out the `@context.target` but also the buffer for the duration of the `capture` block.

I encountered this issue because I was capturing the output of a full HTML document, which was being generated by another Phlex view), for the purposes of passing it as a `srcdoc` to an `<iframe>`. But the closing `</head>` tag in the iframe document was pushing the captured buffer up to that point onto the parent document.

I benchmarked this change and the difference falls within error.