### PR TITLE
Fix `flush` during `capture` by storing capturing state in `Context`

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -4,18 +4,22 @@
 class Phlex::Context
 	def initialize
 		@target = +""
+		@capturing = false
 	end
 
-	attr_accessor :target
+	attr_accessor :target, :capturing
 
-	def with_target(new_target)
+	def capturing_into(new_target)
 		original_target = @target
+		original_capturing = @capturing
 
 		begin
 			@target = new_target
+			@capturing = true
 			yield
 		ensure
 			@target = original_target
+			@capturing = original_capturing
 		end
 
 		new_target

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -182,13 +182,15 @@ module Phlex
 		def capture(&block)
 			return "" unless block
 
-			@_context.with_target(+"") { yield_content(&block) }
+			@_context.capturing_into(+"") { yield_content(&block) }
 		end
 
 		private
 
 		# @api private
 		def flush
+			return if @_context.capturing
+
 			target = @_context.target
 			@_buffer << target.dup
 			target.clear
@@ -240,7 +242,7 @@ module Phlex
 		def __vanish__(*args)
 			return unless block_given?
 
-			@_context.with_target(BlackHole) { yield(*args) }
+			@_context.capturing_into(BlackHole) { yield(*args) }
 
 			nil
 		end


### PR DESCRIPTION
This is a 2nd attempt to solve the issue of flushing inside a capture. My attempt in #566 partially solves the issue, but the problem persists if the flush happens inside of a component that is being rendered by a component that is being captured by another component. So imagine a setup like so:

```rb
class Page < Phlex::HTML
  def template
    render Previewer do
      render FlushingComponent
    end
  end
end

class Previewer < Phlex::HTML
  def template
    srcdoc = capture { yield } if block_given?
    
    iframe srcdoc:
  end
end

class FlushingComponent < Phlex::HTML
  def template
    h1 { "first" }
    flush
    h1 { "second" }
  end
end
```

`Page` is rendering `FlushingComponent`, and `Previewer` is trying to capture it.

This PR attempts to fix the problem the same way this was fixed for `capture` in #526. When a view is called, we take the provided buffer and wrap it in a `Phlex::Context`. This allows all nested components to share the same wrapped buffer, which allows us to take advantage of `with_target` to switch out the underlying buffer during a capture.

## Potential for renaming

I think if this general strategy is acceptable, we may want to brainstorm new names for either `Phlex::Context` or for the `context` buffer shared between components during rendering, or for both.

A possible other name for `Phlex::Context` might be `Phlex::Box` as it reminds me of a [Rust Box](https://doc.rust-lang.org/std/boxed/index.html). `Phlex::BufferWrapper` or `Phlex::Container` I think also work.

If we were to rename the `context` ivar, I might suggest `internal_buffer`. We can thing of `buffer` as something that points outside of Phlex, like a Rack stream. It should be treated as potentially costly to write to. Whereas `internal_buffer` is where we write to most of the time, as we can be sure of its performance cost.