### PR TITLE
Add `SGML#each` to support the Rack interface

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -86,6 +86,11 @@ module Phlex
 			end
 		end
 
+		# Yields each fragment of the view to the given block, which is useful for streaming.
+		def each(&block)
+			Enumerator.new { |e| call(e) }.each(&block)
+		end
+
 		# Renders the view and returns the buffer. The default buffer is a mutable String.
 		def call(buffer = +"", context: Phlex::Context.new, view_context: nil, parent: nil, &block)
 			__final_call__(buffer, context: context, view_context: view_context, parent: parent, &block).tap do

--- a/test/phlex/view/each.rb
+++ b/test/phlex/view/each.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Example < Phlex::HTML
+	def template
+		h1 { "Hello, world!" }
+	end
+end
+
+describe "#each" do
+	it "returns an enumerator" do
+		expect(Example.new.each).to be_a Enumerator
+		expect(Example.new.each.to_a).to be == ([%(<h1>Hello, world!</h1>)])
+	end
+
+	with "block" do
+		it "yields each fragment to the block" do
+			fragments = []
+
+			Example.new.each do |fragment|
+				fragments << fragment
+			end
+
+			expect(fragments).to be == ([%(<h1>Hello, world!</h1>)])
+		end
+	end
+end


### PR DESCRIPTION
Adding `#each` to `SGML` allows us to use Phlex components as streamable responses as part of the rack interface. For example:

```ruby
class MyApp
  def call(request)
    [200, {}, IndexView.new]
  end
end

run MyApp.new
```