### PR TITLE
Allow formatting integers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-latest', 'macos-latest-xlarge']
         ruby-version:
           - '2.7'
           - '3.0'
@@ -21,8 +21,8 @@ jobs:
           - 'truffleruby-22.3'
           - 'truffleruby-head'
 
-          - 'jruby-9.4.0.0'
-          - 'jruby-head'
+          # - 'jruby-9.4.0.0'
+          # - 'jruby-head'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Tests
         run: bundle exec sus
 
-      - name: GreenDots tests
-        run: bundle exec gd gd
-
   rubocop:
     runs-on: 'ubuntu-latest'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
         ruby-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'macos-latest-xlarge']
+        os: ['ubuntu-latest', 'macos-latest']
         ruby-version:
           - '2.7'
           - '3.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,6 @@ Style/ExplicitBlockArgument:
 
 Style/MixinUsage:
   Enabled: false
+
+Style/RedundantDoubleSplatHashBraces:
+  Enabled: false

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -259,7 +259,7 @@ module Phlex
 		# @return [String]
 		def format_object(object)
 			case object
-			when Float
+			when Float, Integer
 				object.to_s
 			end
 		end
@@ -338,8 +338,6 @@ module Phlex
 				@_context.target << ERB::Escape.html_escape(content)
 			when Symbol
 				@_context.target << ERB::Escape.html_escape(content.name)
-			when Integer
-				@_context.target << content.to_s
 			when nil
 				nil
 			else


### PR DESCRIPTION
I’m removing the fast path for rendering Integers because I think it makes sense to be able to format Integers by overriding `format_object`.