### PR TITLE
phlex.gemspec: Drop exe/ mentions

### DIFF
--- a/phlex.gemspec
+++ b/phlex.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |spec|
 			(f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
 		end
 	end
-	spec.bindir = "exe"
-	spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
 	spec.require_paths = ["lib"]
 
 	# Uncomment to register a new dependency of your gem


### PR DESCRIPTION
This PR removes a mention of the non-existent exe/ directory, since the gem exposes no executables.