### PR TITLE
Use `yield_content` in `whitespace`

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -141,13 +141,13 @@ module Phlex
 		# Output a whitespace character. This is useful for getting inline elements to wrap. If you pass a block, a whitespace will be output before and after yielding the block.
 		# @return [nil]
 		# @yield If a block is given, it yields the block with no arguments.
-		def whitespace
+		def whitespace(&block)
 			target = @_context.target
 
 			target << " "
 
 			if block_given?
-				yield
+				yield_content(&block)
 				target << " "
 			end
 

--- a/test/phlex/view/whitespace.rb
+++ b/test/phlex/view/whitespace.rb
@@ -30,4 +30,18 @@ describe Phlex::HTML do
 			expect(output).to be == " <a>Home</a> "
 		end
 	end
+
+	with "whitespace around a string" do
+		view do
+			def template
+				span { "9" }
+				whitespace { "out of" }
+				span { "10" }
+			end
+		end
+
+		it "produces the correct output" do
+			expect(output).to be == "<span>9</span> out of <span>10</span>"
+		end
+	end
 end


### PR DESCRIPTION
This will allow the block form of `whitespace` to work the same way you would work with an element method. Your block can return a string, or any object that can be formatted by `format_object` if it contains no other element methods.

```rb
span { "9" }
whitespace { "out of" }
span { "10" }
```