### PR TITLE
Add support for using the `mix` helper with different types

### DIFF
--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -80,9 +80,23 @@ module Phlex::Helpers
 				when Hash
 					old.is_a?(Hash) ? mix(old, new) : new
 				when Array
-					old.is_a?(Array) ? (old + new) : new
+					case old
+					when Array then old + new
+					when Set then old.to_a + new
+					when Hash then new
+					else
+						[old] + new
+					end
+				when Set
+					case old
+					when Set then old + new
+					when Array then old + new.to_a
+					when Hash then new
+					else
+						new + [old]
+					end
 				when String
-					old.is_a?(String) ? "#{old} #{new}" : new
+					old.is_a?(String) ? "#{old} #{new}" : old + old.class[new]
 				else
 					new
 				end

--- a/test/phlex/view/mix.rb
+++ b/test/phlex/view/mix.rb
@@ -40,4 +40,34 @@ describe Phlex::Helpers do
 
 		expect(output).to be == { data: { controller: "bar" } }
 	end
+
+	it "supports mixing between arrays and strings" do
+		output = mix({ class: ["foo"] }, { class: "bar" })
+
+		expect(output).to be == { class: ["foo", "bar"] }
+
+		output = mix({ class: "foo" }, { class: ["bar"] })
+
+		expect(output).to be == { class: ["foo", "bar"] }
+	end
+
+	it "supports mixing between sets and strings" do
+		output = mix({ class: Set["foo"] }, { class: "bar" })
+
+		expect(output).to be == { class: Set["foo", "bar"] }
+
+		output = mix({ class: "foo" }, { class: Set["bar"] })
+
+		expect(output).to be == { class: Set["foo", "bar"] }
+	end
+
+	it "supports mixing between arrays and sets, keeping the less restrictive type" do
+		output = mix({ class: ["foo"] }, { class: Set["bar"] })
+
+		expect(output).to be == { class: ["foo", "bar"] }
+
+		output = mix({ class: Set["foo"] }, { class: ["bar"] })
+
+		expect(output).to be == { class: ["foo", "bar"] }
+	end
 end


### PR DESCRIPTION
See #613 for examples where this is necessary.

I'm not in love with the approach here, but the double case was what I found easiest to reason about. If you have any suggestions for improvement let me know.