### PR TITLE
Move the Helpers include to parent class so Phlex::SVG subclasses have access

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -22,7 +22,7 @@ module Phlex
 		end
 
 		extend Elements
-		include Helpers, VoidElements, StandardElements
+		include VoidElements, StandardElements
 
 		# Output an HTML doctype.
 		def doctype

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -7,6 +7,8 @@ end
 module Phlex
 	# **Standard Generalized Markup Language** for behaviour common to {HTML} and {SVG}.
 	class SGML
+		include Helpers
+
 		class << self
 			# Render the view to a String. Arguments are delegated to {.new}.
 			def call(...)


### PR DESCRIPTION
I was trying to use `mix` in a Phlex::SVG object but got no method error.