### PR TITLE
Rename `template` → `view_template`

### DIFF
--- a/fixtures/layout.rb
+++ b/fixtures/layout.rb
@@ -6,7 +6,7 @@ module Example
 			@title = title
 		end
 
-		def template(&block)
+		def view_template(&block)
 			html do
 				head do
 					title { @title }

--- a/fixtures/page.rb
+++ b/fixtures/page.rb
@@ -2,7 +2,7 @@
 
 module Example
 	class Page < Phlex::HTML
-		def template
+		def view_template
 			render LayoutComponent.new do
 				h1 { "Hi" }
 

--- a/lib/phlex/deferred_render.rb
+++ b/lib/phlex/deferred_render.rb
@@ -11,7 +11,7 @@
 # 			@tabs = []
 # 		end
 #
-# 		def template
+# 		def view_template
 # 			@tabs.each { |t| a { t.name } }
 # 			@tabs.each { |t| article(&t.content) }
 # 		end

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -15,7 +15,7 @@ end
 # 	class MyComponent < Phlex::HTML
 # 		include MyCustomElements
 #
-# 		def template
+# 		def view_template
 # 			trix_editor
 # 		end
 # 	end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -55,22 +55,32 @@ module Phlex
 
 		# @abstract Override to define a template for your component.
 		# @example
-		# 	def template
+		# 	def view_template
 		# 		h1 { "👋 Hello World!" }
 		# 	end
 		# @example Your template may yield a content block.
-		# 	def template
+		# 	def view_template
 		# 		main {
 		# 			h1 { "Hello World" }
 		# 			yield
 		# 		}
 		# 	end
 		# @example Alternatively, you can delegate the content block to an element.
-		# 	def template(&block)
+		# 	def view_template(&block)
 		# 		article(class: "card", &block)
 		# 	end
 		def template
 			yield
+		end
+
+		def self.method_added(method_name)
+			if method_name == :template
+				Kernel.warn "Defining the `template` method on a Phlex component is deprecated and will be unsupported in Phlex 2.0. Please define `view_template` instead."
+			end
+		end
+
+		def view_template(&)
+			template(&)
 		end
 
 		# @api private
@@ -110,9 +120,9 @@ module Phlex
 				if block
 					if is_a?(DeferredRender)
 						__vanish__(self, &block)
-						template
+						view_template
 					else
-						template do |*args|
+						view_template do |*args|
 							if args.length > 0
 								yield_content_with_args(*args, &block)
 							else
@@ -121,7 +131,7 @@ module Phlex
 						end
 					end
 				else
-					template
+					view_template
 				end
 			end
 

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -79,8 +79,8 @@ module Phlex
 			end
 		end
 
-		def view_template(&)
-			template(&)
+		def view_template(&block)
+			template(&block)
 		end
 
 		# @api private

--- a/test/phlex/callbacks.rb
+++ b/test/phlex/callbacks.rb
@@ -9,7 +9,7 @@ describe Phlex::HTML do
 				h1 { "Hello" }
 			end
 
-			def template
+			def view_template
 				h2 { "World" }
 			end
 

--- a/test/phlex/render_enumerable.rb
+++ b/test/phlex/render_enumerable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Card < Phlex::HTML
-	def template(&block)
+	def view_template(&block)
 		article(&block)
 	end
 end
@@ -14,13 +14,13 @@ class WithoutBlock < Phlex::HTML
 		]
 	end
 
-	def template
+	def view_template
 		render @cards
 	end
 end
 
 class WithBlock < WithoutBlock
-	def template
+	def view_template
 		render @cards do
 			h1 { "Hi" }
 		end

--- a/test/phlex/svg.rb
+++ b/test/phlex/svg.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Example < Phlex::SVG
-	def template
+	def view_template
 		svg do
 			path(d: "123")
 		end
@@ -9,7 +9,7 @@ class Example < Phlex::SVG
 end
 
 class ExampleFromHTML < Phlex::HTML
-	def template
+	def view_template
 		svg do |s|
 			s.path(d: "321")
 		end

--- a/test/phlex/testing/view_helper.rb
+++ b/test/phlex/testing/view_helper.rb
@@ -3,13 +3,13 @@
 require "phlex/testing/view_helper"
 
 class ExampleHTML < Phlex::HTML
-	def template
+	def view_template
 		h1 { "👋" }
 	end
 end
 
 class ExampleSVG < Phlex::SVG
-	def template
+	def view_template
 		svg do
 			path(d: "123")
 		end

--- a/test/phlex/unbuffered.rb
+++ b/test/phlex/unbuffered.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Example < Phlex::HTML
-	def template
+	def view_template
 		yield
 	end
 

--- a/test/phlex/view/around_template.rb
+++ b/test/phlex/view/around_template.rb
@@ -11,7 +11,7 @@ describe Phlex::HTML do
 				h3 { "After" }
 			end
 
-			def template
+			def view_template
 				h2 { "Hello" }
 			end
 		end

--- a/test/phlex/view/call.rb
+++ b/test/phlex/view/call.rb
@@ -4,7 +4,7 @@ describe Phlex::HTML do
 	extend ViewHelper
 
 	view do
-		def template
+		def view_template
 			plain "Hi"
 		end
 	end
@@ -17,7 +17,7 @@ describe Phlex::HTML do
 
 	with "`render?` method returning false when the view context is true" do
 		view do
-			def template
+			def view_template
 				plain "Hi"
 			end
 
@@ -29,7 +29,7 @@ describe Phlex::HTML do
 
 	with "a view that yields an object" do
 		view do
-			def template
+			def view_template
 				yield(1, 2)
 			end
 		end
@@ -47,7 +47,7 @@ describe Phlex::HTML do
 
 	with "a view that yields nothing" do
 		view do
-			def template
+			def view_template
 				yield
 			end
 

--- a/test/phlex/view/capture.rb
+++ b/test/phlex/view/capture.rb
@@ -7,7 +7,7 @@ describe Phlex::HTML do
 		view do
 			attr_accessor :captured
 
-			def template
+			def view_template
 				h1 { "Before" }
 				@captured = capture { "Hello" }
 				h1 { "After" }
@@ -24,7 +24,7 @@ describe Phlex::HTML do
 		view do
 			attr_accessor :captured
 
-			def template
+			def view_template
 				h1 { "Before" }
 				@captured = capture do
 					h1 { "Hello" }
@@ -43,7 +43,7 @@ describe Phlex::HTML do
 		view do
 			attr_accessor :captured
 
-			def template
+			def view_template
 				h1 { "Before" }
 				@captured = capture do
 					h1 { "Hello" }
@@ -63,7 +63,7 @@ describe Phlex::HTML do
 	with "a call to flush inside a component rendered in the block" do
 		let(:component) do
 			Class.new(Phlex::HTML) do
-				def template
+				def view_template
 					h1 { "Hello" }
 					flush
 					h1 { "World" }
@@ -73,7 +73,7 @@ describe Phlex::HTML do
 
 		let(:previewer) do
 			Class.new(Phlex::HTML) do
-				def template
+				def view_template
 					srcdoc = capture { yield } if block_given?
 
 					iframe srcdoc: srcdoc
@@ -82,7 +82,7 @@ describe Phlex::HTML do
 		end
 
 		view do
-			def template
+			def view_template
 				h1 { "Before" }
 				render @_view_context.previewer do
 					render @_view_context.component

--- a/test/phlex/view/comment.rb
+++ b/test/phlex/view/comment.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "simple comment" do
 		view do
-			def template
+			def view_template
 				comment { "This is an HTML comment" }
 			end
 		end
@@ -17,7 +17,7 @@ describe Phlex::HTML do
 
 	with "empty comment" do
 		view do
-			def template
+			def view_template
 				comment
 			end
 		end
@@ -29,7 +29,7 @@ describe Phlex::HTML do
 
 	with "number comment" do
 		view do
-			def template
+			def view_template
 				comment { 1 }
 			end
 		end
@@ -41,7 +41,7 @@ describe Phlex::HTML do
 
 	with "escaped comment" do
 		view do
-			def template
+			def view_template
 				comment { "<b>Important</b>" }
 			end
 		end

--- a/test/phlex/view/content.rb
+++ b/test/phlex/view/content.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "content" do
 		view do
-			def template
+			def view_template
 				h1 { "Before" }
 				yield
 				h2 { "After" }

--- a/test/phlex/view/custom_elements.rb
+++ b/test/phlex/view/custom_elements.rb
@@ -8,7 +8,7 @@ describe Phlex::HTML do
 			register_element :trix_editor
 			register_element :trix_toolbar
 
-			def template
+			def view_template
 				div do
 					trix_toolbar
 					trix_editor { "Hello" }

--- a/test/phlex/view/doctype.rb
+++ b/test/phlex/view/doctype.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "a doctype" do
 		view do
-			def template
+			def view_template
 				html do
 					head { doctype }
 				end

--- a/test/phlex/view/format_object.rb
+++ b/test/phlex/view/format_object.rb
@@ -3,7 +3,7 @@
 require "date"
 
 class Example < Phlex::HTML
-	def template
+	def view_template
 		h1 { Date.new(2022, 11, 28) }
 	end
 

--- a/test/phlex/view/legacy_template_method.rb
+++ b/test/phlex/view/legacy_template_method.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe Phlex::SGML do
+	it "warns when you define a template" do
+		expect(Kernel).to receive(:warn)
+
+		class Example < Phlex::HTML
+			def template
+				h1 { "Hello, world!" }
+			end
+		end
+
+		expect(
+			Example.new.call
+		).to be == "<h1>Hello, world!</h1>"
+	end
+end

--- a/test/phlex/view/legacy_template_method.rb
+++ b/test/phlex/view/legacy_template_method.rb
@@ -4,14 +4,14 @@ describe Phlex::SGML do
 	it "warns when you define a template" do
 		expect(Kernel).to receive(:warn)
 
-		class Example < Phlex::HTML
+		example = Class.new(Phlex::HTML) do
 			def template
 				h1 { "Hello, world!" }
 			end
 		end
 
 		expect(
-			Example.new.call
+			example.new.call
 		).to be == "<h1>Hello, world!</h1>"
 	end
 end

--- a/test/phlex/view/naughty_business.rb
+++ b/test/phlex/view/naughty_business.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "naughty text" do
 		view do
-			def template
+			def view_template
 				plain %("><script type="text/javascript" src="bad_script.js"></script>)
 			end
 		end
@@ -17,7 +17,7 @@ describe Phlex::HTML do
 
 	with "naughty tag attribute values" do
 		view do
-			def template
+			def view_template
 				article id: %("><script type="text/javascript" src="bad_script.js"></script>)
 			end
 		end
@@ -29,7 +29,7 @@ describe Phlex::HTML do
 
 	with "naughty javascript link protocol in href" do
 		view do
-			def template
+			def view_template
 				a href: "javascript:javascript:alert(1)" do
 					"naughty link"
 				end
@@ -43,7 +43,7 @@ describe Phlex::HTML do
 
 	with "naughty javascript link protocol in href" do
 		view do
-			def template
+			def view_template
 				a "href" => "javascript:javascript:alert(1)" do
 					"naughty link"
 				end
@@ -60,7 +60,7 @@ describe Phlex::HTML do
 			naughty_attributes = { event_attribute => "alert(1);" }
 
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(:div, **naughty_attributes)
 				end
 			end
@@ -78,7 +78,7 @@ describe Phlex::HTML do
 			naughty_attributes = { naughty_attribute => "alert(1);" }
 
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(:div, **naughty_attributes)
 				end
 			end

--- a/test/phlex/view/new.rb
+++ b/test/phlex/view/new.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Example < Phlex::HTML
-	def template(&block)
+	def view_template(&block)
 		h1(&block)
 	end
 end
@@ -16,7 +16,7 @@ class ExampleWithArgs < Phlex::HTML
 		@should_render
 	end
 
-	def template
+	def view_template
 		h1 {
 			yield
 			plain(", #{@name}")
@@ -29,7 +29,7 @@ describe Phlex::HTML do
 
 	with "a block passed to new" do
 		view do
-			def template
+			def view_template
 				render Example.new { "Hello" }
 			end
 		end
@@ -41,7 +41,7 @@ describe Phlex::HTML do
 
 	with "a block and arguments passed to new" do
 		view do
-			def template
+			def view_template
 				render ExampleWithArgs.new("World", should_render: true) { "Hello" }
 			end
 		end

--- a/test/phlex/view/numbers.rb
+++ b/test/phlex/view/numbers.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "numbers" do
 		view do
-			def template
+			def view_template
 				span { 1 }
 
 				span { 2.0 }

--- a/test/phlex/view/plain.rb
+++ b/test/phlex/view/plain.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "text" do
 		view do
-			def template
+			def view_template
 				plain "Hi"
 			end
 		end
@@ -17,7 +17,7 @@ describe Phlex::HTML do
 
 	with "int as text" do
 		view do
-			def template
+			def view_template
 				plain 1
 			end
 		end
@@ -29,7 +29,7 @@ describe Phlex::HTML do
 
 	with "float as text" do
 		view do
-			def template
+			def view_template
 				plain 2.0
 			end
 		end
@@ -41,7 +41,7 @@ describe Phlex::HTML do
 
 	with "an object that has no special format_object handling" do
 		view do
-			def template
+			def view_template
 				plain Object.new
 			end
 		end

--- a/test/phlex/view/process_attributes.rb
+++ b/test/phlex/view/process_attributes.rb
@@ -4,7 +4,7 @@ describe Phlex::HTML do
 	extend ViewHelper
 
 	view do
-		def template
+		def view_template
 			div(class: "foo")
 		end
 

--- a/test/phlex/view/renderable/render.rb
+++ b/test/phlex/view/renderable/render.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Example < Phlex::HTML
-	def template
+	def view_template
 		h1 { "Hello" }
 	end
 end
@@ -12,7 +12,7 @@ describe Phlex::HTML do
 	describe "#render" do
 		with "a view class" do
 			view do
-				def template
+				def view_template
 					render Example
 				end
 			end
@@ -24,14 +24,14 @@ describe Phlex::HTML do
 
 		with "another view" do
 			other_view = Class.new Phlex::HTML do
-				def template(&block)
+				def view_template(&block)
 					div(&block)
 				end
 			end
 
 			with "markup" do
 				view do
-					define_method :template do
+					define_method :view_template do
 						render(other_view.new) do
 							h1 { "Hi!" }
 						end
@@ -45,7 +45,7 @@ describe Phlex::HTML do
 
 			with "text" do
 				view do
-					define_method :template do
+					define_method :view_template do
 						render(other_view.new) { "Hello world!" }
 					end
 				end
@@ -57,7 +57,7 @@ describe Phlex::HTML do
 
 			with "0-argument lambda" do
 				view do
-					define_method :template do
+					define_method :view_template do
 						render -> { h1 { "Hi" } }
 					end
 				end
@@ -69,7 +69,7 @@ describe Phlex::HTML do
 
 			with "1-argument lambda" do
 				view do
-					define_method :template do
+					define_method :view_template do
 						render -> (_view) { h1 { "Hi" } }
 					end
 				end
@@ -81,7 +81,7 @@ describe Phlex::HTML do
 
 			with "multi-argument proc" do
 				view do
-					define_method :template do
+					define_method :view_template do
 						render proc { |_a, _b, _c| h1 { "Hi" } }
 					end
 				end

--- a/test/phlex/view/static_call.rb
+++ b/test/phlex/view/static_call.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Example < Phlex::HTML
-	def template
+	def view_template
 		h1 { "Hi" }
 	end
 end

--- a/test/phlex/view/svg_tags.rb
+++ b/test/phlex/view/svg_tags.rb
@@ -6,7 +6,7 @@ describe Phlex::SVG do
 	Phlex::SVG::StandardElements.registered_elements.each do |method_name, tag|
 		with "<#{tag}> called with an underscore prefix while overridden" do
 			svg_view do
-				define_method :template do
+				define_method :view_template do
 					send("_#{method_name}")
 				end
 
@@ -22,7 +22,7 @@ describe Phlex::SVG do
 
 		with "<#{tag}> with block content and attributes" do
 			svg_view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { text { "Hello" } }
 				end
 			end
@@ -34,7 +34,7 @@ describe Phlex::SVG do
 
 		with "<#{tag}> with block text content and attributes" do
 			svg_view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { "content" }
 				end
 			end

--- a/test/phlex/view/tags.rb
+++ b/test/phlex/view/tags.rb
@@ -6,7 +6,7 @@ describe Phlex::HTML do
 	Phlex::HTML::StandardElements.registered_elements.each do |method_name, tag|
 		with "<#{tag}> called with an underscore prefix while overridden" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send("_#{method_name}")
 				end
 
@@ -22,7 +22,7 @@ describe Phlex::HTML do
 
 		with "<#{tag}> with block content and attributes" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { h1 { "Hello" } }
 				end
 			end
@@ -34,7 +34,7 @@ describe Phlex::HTML do
 
 		with "<#{tag}> with block text content and attributes" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { "content" }
 				end
 			end
@@ -46,7 +46,7 @@ describe Phlex::HTML do
 
 		with "<#{tag}> with string attribute keys" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, "attribute_with_underscore" => true) { "content" }
 				end
 			end
@@ -58,7 +58,7 @@ describe Phlex::HTML do
 
 		with "<#{tag}> with hash attribute values" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, aria: { hidden: true }, data_turbo: { frame: "_top" }) { "content" }
 				end
 			end
@@ -72,7 +72,7 @@ describe Phlex::HTML do
 	Phlex::HTML::VoidElements.registered_elements.each do |method_name, tag|
 		with "<#{tag}> called with an underscore prefix while overridden" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send("_#{method_name}")
 				end
 
@@ -88,7 +88,7 @@ describe Phlex::HTML do
 
 		with "<#{tag}> with attributes" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false)
 				end
 			end
@@ -100,7 +100,7 @@ describe Phlex::HTML do
 
 		with "<#{tag}> with string attribute keys" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, "attribute_with_underscore" => true)
 				end
 			end
@@ -112,7 +112,7 @@ describe Phlex::HTML do
 
 		with "<#{tag}> with hash attribute values" do
 			view do
-				define_method :template do
+				define_method :view_template do
 					send(method_name, aria: { hidden: true }, data_turbo: { frame: "_top" })
 				end
 			end

--- a/test/phlex/view/tokens.rb
+++ b/test/phlex/view/tokens.rb
@@ -6,7 +6,7 @@ describe Phlex::HTML do
 	with "conditional classes" do
 		with "symbol conditionals" do
 			view do
-				def template
+				def view_template
 					a href: "/", **classes("a", "b", "c", active?: "active", primary?: ["primary", "d"]) do
 						"Home"
 					end
@@ -29,7 +29,7 @@ describe Phlex::HTML do
 
 		with "proc conditionals" do
 			view do
-				def template
+				def view_template
 					a href: "/", **classes("a", "b", "c",
 						-> { true } => "true",
 						-> { false } => "false") do
@@ -46,7 +46,7 @@ describe Phlex::HTML do
 
 		with "negative conditionals" do
 			view do
-				def template
+				def view_template
 					a href: "/", **classes("a", "b", "c",
 						active?: {
 							then: "active",
@@ -69,7 +69,7 @@ describe Phlex::HTML do
 
 		with "no truthy conditionals" do
 			view do
-				def template
+				def view_template
 					a href: "/", **classes(
 						active?: {
 							then: "active"
@@ -92,7 +92,7 @@ describe Phlex::HTML do
 
 		with "nils and empty strings" do
 			view do
-				def template
+				def view_template
 					div(class: tokens("", nil, false, "foo", "", nil, false, "bar", "", nil, false))
 				end
 			end

--- a/test/phlex/view/unsafe_raw.rb
+++ b/test/phlex/view/unsafe_raw.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "raw content" do
 		view do
-			def template
+			def view_template
 				unsafe_raw %(<h1 class="test">Hello</h1>)
 			end
 		end
@@ -17,7 +17,7 @@ describe Phlex::HTML do
 
 	with "nil content" do
 		view do
-			def template
+			def view_template
 				unsafe_raw nil
 			end
 		end

--- a/test/phlex/view/whitespace.rb
+++ b/test/phlex/view/whitespace.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "whitespace" do
 		view do
-			def template
+			def view_template
 				a { "Home" }
 				whitespace
 				a { "About" }
@@ -19,7 +19,7 @@ describe Phlex::HTML do
 
 	with "whitespace around" do
 		view do
-			def template
+			def view_template
 				whitespace do
 					a { "Home" }
 				end
@@ -33,7 +33,7 @@ describe Phlex::HTML do
 
 	with "whitespace around a string" do
 		view do
-			def template
+			def view_template
 				span { "9" }
 				whitespace { "out of" }
 				span { "10" }


### PR DESCRIPTION
This is a non-breaking rename that issues a warning whenever you define `template`.