### PR TITLE
Update HTML elements

### DIFF
--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -32,7 +32,7 @@ module Phlex::Elements
 	# @note The methods defined by this macro depend on other methods from {SGML} so they should always be mixed into an {HTML} or {SVG} component.
 	# @example Register the custom element `<trix-editor>`
 	# 	register_element :trix_editor
-	def register_element(method_name, tag: nil)
+	def register_element(method_name, tag: nil, deprecated: false)
 		tag ||= method_name.name.tr("_", "-")
 
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
@@ -73,7 +73,7 @@ module Phlex::Elements
 	end
 
 	# @api private
-	def register_void_element(method_name, tag: method_name.name.tr("_", "-"))
+	def register_void_element(method_name, tag: method_name.name.tr("_", "-"), deprecated: false)
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 

--- a/lib/phlex/html/standard_elements.rb
+++ b/lib/phlex/html/standard_elements.rb
@@ -39,12 +39,26 @@ module Phlex::HTML::StandardElements
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/aside
 	register_element :aside, tag: "aside"
 
+	# @!method audio(**attributes, &content)
+	# 	Outputs an `<audio>` tag.
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
+	register_element :audio, tag: "audio"
+
 	# @!method b(**attributes, &content)
 	# 	Outputs a `<b>` tag.
 	# 	@return [nil]
 	# 	@yieldparam component [self]
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/b
 	register_element :b, tag: "b"
+
+	# @!method base(**attributes, &content)
+	# 	Outputs a `<base>` tag.
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+	register_element :base, tag: "base"
 
 	# @!method bdi(**attributes, &content)
 	# 	Outputs a `<bdi>` tag.
@@ -368,6 +382,13 @@ module Phlex::HTML::StandardElements
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/mark
 	register_element :mark, tag: "mark"
 
+	# @!method menu(**attributes, &content)
+	# 	Outputs a `<menu>` tag.
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
+	register_element :menu, tag: "menu"
+
 	# @!method meter(**attributes, &content)
 	# 	Outputs a `<meter>` tag.
 	# 	@return [nil]
@@ -438,6 +459,13 @@ module Phlex::HTML::StandardElements
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/picture
 	register_element :picture, tag: "picture"
 
+	# @!method portal(**attributes, &content)
+	# 	Outputs a `<portal>` tag. (Experimental)
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/portal
+	register_element :portal, tag: "portal"
+
 	# @!method pre(**attributes, &content)
 	# 	Outputs a `<pre>` tag.
 	# 	@return [nil]
@@ -474,7 +502,7 @@ module Phlex::HTML::StandardElements
 	register_element :rt, tag: "rt"
 
 	# @!method ruby(**attributes, &content)
-	# 	Outputs a `<ruby>` tag.
+	# 	Outputs a `<ruby>` tag. (The best tag ever!)
 	# 	@return [nil]
 	# 	@yieldparam component [self]
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/ruby
@@ -500,6 +528,13 @@ module Phlex::HTML::StandardElements
 	# 	@yieldparam component [self]
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/script
 	register_element :script, tag: "script"
+
+	# @!method search(**attributes, &content)
+	# 	Outputs a `<search>` tag.
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
+	register_element :search, tag: "search"
 
 	# @!method section(**attributes, &content)
 	# 	Outputs a `<section>` tag.
@@ -668,6 +703,13 @@ module Phlex::HTML::StandardElements
 	# 	@yieldparam component [self]
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/ul
 	register_element :ul, tag: "ul"
+
+	# @!method var(**attributes, &content)
+	# 	Outputs a `<var>` tag.
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
+	register_element :var, tag: "var"
 
 	# @!method video(**attributes, &content)
 	# 	Outputs a `<video>` tag.

--- a/lib/phlex/html/void_elements.rb
+++ b/lib/phlex/html/void_elements.rb
@@ -16,6 +16,12 @@ module Phlex::HTML::VoidElements
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/br
 	register_void_element :br, tag: "br"
 
+	# @!method col(**attributes, &content)
+	# 	Outputs a `<col>` tag.
+	# 	@return [nil]
+	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/col
+	register_void_element :col, tag: "col"
+
 	# @!method embed(**attributes, &content)
 	# 	Outputs an `<embed>` tag.
 	# 	@return [nil]
@@ -56,7 +62,7 @@ module Phlex::HTML::VoidElements
 	# 	Outputs a `<param>` tag.
 	# 	@return [nil]
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/param
-	register_void_element :param, tag: "param"
+	register_void_element :param, tag: "param", deprecated: true
 
 	# @!method source(**attributes, &content)
 	# 	Outputs a `<source>` tag.
@@ -69,10 +75,4 @@ module Phlex::HTML::VoidElements
 	# 	@return [nil]
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/track
 	register_void_element :track, tag: "track"
-
-	# @!method col(**attributes, &content)
-	# 	Outputs a `<col>` tag.
-	# 	@return [nil]
-	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/col
-	register_void_element :col, tag: "col"
 end


### PR DESCRIPTION
Add `<audio>`, `<base>`, `<menu>`, `<portal>`, `<search>` and `<var>`.

I also flagged `<param>` as deprecated, though I haven't updated the method generator to do anything with this information yet.

After this, Phlex supports *all* non-deprecated HTML5 elements, so we can update the documentation accordingly (it currently says we only support the most popular).