### PR TITLE
Remove view_context

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -95,17 +95,16 @@ module Phlex
 		end
 
 		# Renders the view and returns the buffer. The default buffer is a mutable String.
-		def call(buffer = +"", context: Phlex::Context.new, view_context: nil, parent: nil, &block)
-			__final_call__(buffer, context: context, view_context: view_context, parent: parent, &block).tap do
+		def call(...)
+			__final_call__(...).tap do
 				self.class.rendered_at_least_once!
 			end
 		end
 
 		# @api private
-		def __final_call__(buffer = +"", context: Phlex::Context.new, view_context: nil, parent: nil, &block)
+		def __final_call__(buffer = +"", context: Phlex::Context.new, parent: nil, &block)
 			@_buffer = buffer
 			@_context = context
-			@_view_context = view_context
 			@_parent = parent
 
 			block ||= @_content_block
@@ -223,10 +222,10 @@ module Phlex
 		def render(renderable, &block)
 			case renderable
 			when Phlex::SGML
-				renderable.call(@_buffer, context: @_context, view_context: @_view_context, parent: self, &block)
+				renderable.call(@_buffer, context: @_context, parent: self, &block)
 			when Class
 				if renderable < Phlex::SGML
-					renderable.new.call(@_buffer, context: @_context, view_context: @_view_context, parent: self, &block)
+					renderable.new.call(@_buffer, context: @_context, parent: self, &block)
 				end
 			when Enumerable
 				renderable.each { |r| render(r, &block) }

--- a/lib/phlex/testing/view_helper.rb
+++ b/lib/phlex/testing/view_helper.rb
@@ -7,11 +7,7 @@ module Phlex::Testing
 				view = view.new
 			end
 
-			view.call(view_context: view_context, &block)
-		end
-
-		def view_context
-			nil
+			view.call(&block)
 		end
 	end
 end

--- a/test/phlex/view/call.rb
+++ b/test/phlex/view/call.rb
@@ -15,18 +15,6 @@ describe Phlex::HTML do
 		end
 	end
 
-	with "`render?` method returning false when the view context is true" do
-		view do
-			def view_template
-				plain "Hi"
-			end
-
-			def render?
-				!@_view_context
-			end
-		end
-	end
-
 	with "a view that yields an object" do
 		view do
 			def view_template

--- a/test/phlex/view/capture.rb
+++ b/test/phlex/view/capture.rb
@@ -84,20 +84,29 @@ describe Phlex::HTML do
 		view do
 			def view_template
 				h1 { "Before" }
-				render @_view_context.previewer do
-					render @_view_context.component
+				render @_context.view_context.previewer do
+					render @_context.view_context.component
 				end
 				h1 { "After" }
 			end
 		end
 
+		let(:context) do
+			Phlex::Context.new.tap do |context|
+				class << context
+					attr_accessor :view_context
+				end
+				context.view_context = self
+			end
+		end
+
 		it "should contain the full capture" do
-			expect(example.call(view_context: self)).to be == %(<h1>Before</h1><iframe srcdoc="&lt;h1&gt;Hello&lt;/h1&gt;&lt;h1&gt;World&lt;/h1&gt;"></iframe><h1>After</h1>)
+			expect(example.call(context: context)).to be == %(<h1>Before</h1><iframe srcdoc="&lt;h1&gt;Hello&lt;/h1&gt;&lt;h1&gt;World&lt;/h1&gt;"></iframe><h1>After</h1>)
 		end
 
 		it "should contain the full capture if the buffer is provided" do
 			my_buffer = +""
-			example.call(my_buffer, view_context: self)
+			example.call(my_buffer, context: context)
 			expect(my_buffer).to be == %(<h1>Before</h1><iframe srcdoc="&lt;h1&gt;Hello&lt;/h1&gt;&lt;h1&gt;World&lt;/h1&gt;"></iframe><h1>After</h1>)
 		end
 	end


### PR DESCRIPTION
`view_context` is a Rails concern and is now being handled in the phlex-rails gem.

Closes #628