### PR TITLE
Public Context

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -2,12 +2,13 @@
 
 # @api private
 class Phlex::Context
-	def initialize
+	def initialize(user_context = {})
 		@target = +""
 		@capturing = false
+		@user_context = user_context
 	end
 
-	attr_accessor :target, :capturing
+	attr_accessor :target, :capturing, :user_context
 
 	def capturing_into(new_target)
 		original_target = @target

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -102,10 +102,10 @@ module Phlex
 		end
 
 		# @api private
-		def __final_call__(buffer = +"", context: Phlex::Context.new, parent: nil, &block)
+		def __final_call__(buffer = +"", context: {}, _context: Phlex::Context.new(context), _parent: nil, &block)
 			@_buffer = buffer
-			@_context = context
-			@_parent = parent
+			@_context = _context
+			@_parent = _parent
 
 			block ||= @_content_block
 
@@ -130,7 +130,13 @@ module Phlex
 				end
 			end
 
-			buffer << context.target unless parent
+			buffer << _context.target unless _parent
+		end
+
+		# Access the current render context data
+		# @return the supplied context object, by default a Hash
+		def context
+			@_context.user_context
 		end
 
 		# Output text content. The text will be HTML-escaped.
@@ -222,10 +228,10 @@ module Phlex
 		def render(renderable, &block)
 			case renderable
 			when Phlex::SGML
-				renderable.call(@_buffer, context: @_context, parent: self, &block)
+				renderable.call(@_buffer, _context: @_context, _parent: self, &block)
 			when Class
 				if renderable < Phlex::SGML
-					renderable.new.call(@_buffer, context: @_context, parent: self, &block)
+					renderable.new.call(@_buffer, _context: @_context, _parent: self, &block)
 				end
 			when Enumerable
 				renderable.each { |r| render(r, &block) }

--- a/test/phlex/view/capture.rb
+++ b/test/phlex/view/capture.rb
@@ -84,20 +84,15 @@ describe Phlex::HTML do
 		view do
 			def view_template
 				h1 { "Before" }
-				render @_context.view_context.previewer do
-					render @_context.view_context.component
+				render context[:test_scope].previewer do
+					render context[:test_scope].component
 				end
 				h1 { "After" }
 			end
 		end
 
 		let(:context) do
-			Phlex::Context.new.tap do |context|
-				class << context
-					attr_accessor :view_context
-				end
-				context.view_context = self
-			end
+			{ test_scope: self }
 		end
 
 		it "should contain the full capture" do

--- a/test/phlex/view/context.rb
+++ b/test/phlex/view/context.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe Phlex::HTML do
+	extend ViewHelper
+
+	with "context" do
+		view do
+			def view_template
+				div(class: tokens(-> { context[:theme] == :dark } => { then: "dark", else: "light" }))
+			end
+		end
+
+		with "theme: dark" do
+			let(:context) do
+				{ theme: :dark }
+			end
+
+			it "renders with a dark class" do
+				expect(example.call(context:)).to be == %(<div class="dark"></div>)
+			end
+		end
+
+		with "theme: light" do
+			let(:context) do
+				{ theme: :light }
+			end
+
+			it "renders with a light class" do
+				expect(example.call(context:)).to be == %(<div class="light"></div>)
+			end
+		end
+	end
+end


### PR DESCRIPTION
I wanted to open this draft PR so we had a space to talk about the API here.

* Internally I've called this data `user_context`
* The public API to access it is just at `context`
* To allow for setting `user_context` through the `call` method, I've needed to rename the existing `context` keyword argument. So I made both it and `parent` use our internal naming scheme `_context:, _parent:`
* `context` is by default an empty Hash

What are everyone's thoughts?