### PR TITLE
Rename `target` → `buffer`

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -9,6 +9,11 @@ class Phlex::Context
 
 	attr_accessor :buffer, :capturing
 
+	# Added for backwards compatibility with phlex-rails. We can remove this with 2.0
+	def target
+		@buffer
+	end
+
 	def capturing_into(new_buffer)
 		original_buffer = @buffer
 		original_capturing = @capturing

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -3,22 +3,22 @@
 # @api private
 class Phlex::Context
 	def initialize
-		@target = +""
+		@buffer = +""
 		@capturing = false
 	end
 
-	attr_accessor :target, :capturing
+	attr_accessor :buffer, :capturing
 
 	def capturing_into(new_target)
-		original_target = @target
+		original_buffer = @buffer
 		original_capturing = @capturing
 
 		begin
-			@target = new_target
+			@buffer = new_target
 			@capturing = true
 			yield
 		ensure
-			@target = original_target
+			@buffer = original_buffer
 			@capturing = original_capturing
 		end
 

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -9,12 +9,12 @@ class Phlex::Context
 
 	attr_accessor :buffer, :capturing
 
-	def capturing_into(new_target)
+	def capturing_into(new_buffer)
 		original_buffer = @buffer
 		original_capturing = @capturing
 
 		begin
-			@buffer = new_target
+			@buffer = new_buffer
 			@capturing = true
 			yield
 		ensure
@@ -22,6 +22,6 @@ class Phlex::Context
 			@capturing = original_capturing
 		end
 
-		new_target
+		new_buffer
 	end
 end

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -42,23 +42,23 @@ module Phlex::Elements
 
 			def #{method_name}(**attributes, &block)
 				#{deprecation}
-				target = @_context.buffer
+				buffer = @_context.buffer
 
 				if attributes.length > 0 # with attributes
 					if block # with content block
-						target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
+						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 						yield_content(&block)
-						target << "</#{tag}>"
+						buffer << "</#{tag}>"
 					else # without content block
-						target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
+						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
 					end
 				else # without attributes
 					if block # with content block
-						target << "<#{tag}>"
+						buffer << "<#{tag}>"
 						yield_content(&block)
-						target << "</#{tag}>"
+						buffer << "</#{tag}>"
 					else # without content block
-						target << "<#{tag}></#{tag}>"
+						buffer << "<#{tag}></#{tag}>"
 					end
 				end
 
@@ -90,12 +90,12 @@ module Phlex::Elements
 
 			def #{method_name}(**attributes)
 				#{deprecation}
-				target = @_context.buffer
+				buffer = @_context.buffer
 
 				if attributes.length > 0 # with attributes
-					target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
+					buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 				else # without attributes
-					target << "<#{tag}>"
+					buffer << "<#{tag}>"
 				end
 
 				nil

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -42,7 +42,7 @@ module Phlex::Elements
 
 			def #{method_name}(**attributes, &block)
 				#{deprecation}
-				target = @_context.target
+				target = @_context.buffer
 
 				if attributes.length > 0 # with attributes
 					if block # with content block
@@ -90,7 +90,7 @@ module Phlex::Elements
 
 			def #{method_name}(**attributes)
 				#{deprecation}
-				target = @_context.target
+				target = @_context.buffer
 
 				if attributes.length > 0 # with attributes
 					target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -29,7 +29,7 @@ module Phlex
 
 		# Output an HTML doctype.
 		def doctype
-			@_context.target << "<!DOCTYPE html>"
+			@_context.buffer << "<!DOCTYPE html>"
 			nil
 		end
 

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -131,7 +131,7 @@ module Phlex
 				end
 			end
 
-			buffer << context.target unless parent
+			buffer << context.buffer unless parent
 		end
 
 		# Output text content. The text will be HTML-escaped.
@@ -150,7 +150,7 @@ module Phlex
 		# @return [nil]
 		# @yield If a block is given, it yields the block with no arguments.
 		def whitespace(&block)
-			target = @_context.target
+			target = @_context.buffer
 
 			target << " "
 
@@ -165,7 +165,7 @@ module Phlex
 		# Output an HTML comment.
 		# @return [nil]
 		def comment(&block)
-			target = @_context.target
+			target = @_context.buffer
 
 			target << "<!-- "
 			yield_content(&block)
@@ -180,7 +180,7 @@ module Phlex
 		def unsafe_raw(content = nil)
 			return nil unless content
 
-			@_context.target << content
+			@_context.buffer << content
 			nil
 		end
 
@@ -199,7 +199,7 @@ module Phlex
 		def flush
 			return if @_context.capturing
 
-			target = @_context.target
+			target = @_context.buffer
 			@_buffer << target.dup
 			target.clear
 		end
@@ -302,7 +302,7 @@ module Phlex
 		def yield_content
 			return unless block_given?
 
-			target = @_context.target
+			target = @_context.buffer
 
 			original_length = target.length
 			content = yield(self)
@@ -316,7 +316,7 @@ module Phlex
 		def yield_content_with_no_args
 			return unless block_given?
 
-			target = @_context.target
+			target = @_context.buffer
 
 			original_length = target.length
 			content = yield
@@ -331,7 +331,7 @@ module Phlex
 		def yield_content_with_args(*args)
 			return unless block_given?
 
-			target = @_context.target
+			target = @_context.buffer
 
 			original_length = target.length
 			content = yield(*args)
@@ -345,14 +345,14 @@ module Phlex
 		def __text__(content)
 			case content
 			when String
-				@_context.target << Phlex::Escape.html_escape(content)
+				@_context.buffer << Phlex::Escape.html_escape(content)
 			when Symbol
-				@_context.target << Phlex::Escape.html_escape(content.name)
+				@_context.buffer << Phlex::Escape.html_escape(content.name)
 			when nil
 				nil
 			else
 				if (formatted_object = format_object(content))
-					@_context.target << Phlex::Escape.html_escape(formatted_object)
+					@_context.buffer << Phlex::Escape.html_escape(formatted_object)
 				else
 					return false
 				end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -150,13 +150,13 @@ module Phlex
 		# @return [nil]
 		# @yield If a block is given, it yields the block with no arguments.
 		def whitespace(&block)
-			target = @_context.buffer
+			buffer = @_context.buffer
 
-			target << " "
+			buffer << " "
 
 			if block_given?
 				yield_content(&block)
-				target << " "
+				buffer << " "
 			end
 
 			nil
@@ -165,11 +165,11 @@ module Phlex
 		# Output an HTML comment.
 		# @return [nil]
 		def comment(&block)
-			target = @_context.buffer
+			buffer = @_context.buffer
 
-			target << "<!-- "
+			buffer << "<!-- "
 			yield_content(&block)
-			target << " -->"
+			buffer << " -->"
 
 			nil
 		end
@@ -199,9 +199,9 @@ module Phlex
 		def flush
 			return if @_context.capturing
 
-			target = @_context.buffer
-			@_buffer << target.dup
-			target.clear
+			buffer = @_context.buffer
+			@_buffer << buffer.dup
+			buffer.clear
 		end
 
 		# Render another component, block or enumerable
@@ -302,11 +302,11 @@ module Phlex
 		def yield_content
 			return unless block_given?
 
-			target = @_context.buffer
+			buffer = @_context.buffer
 
-			original_length = target.length
+			original_length = buffer.length
 			content = yield(self)
-			__text__(content) if original_length == target.length
+			__text__(content) if original_length == buffer.length
 
 			nil
 		end
@@ -316,11 +316,11 @@ module Phlex
 		def yield_content_with_no_args
 			return unless block_given?
 
-			target = @_context.buffer
+			buffer = @_context.buffer
 
-			original_length = target.length
+			original_length = buffer.length
 			content = yield
-			__text__(content) if original_length == target.length
+			__text__(content) if original_length == buffer.length
 
 			nil
 		end
@@ -331,11 +331,11 @@ module Phlex
 		def yield_content_with_args(*args)
 			return unless block_given?
 
-			target = @_context.buffer
+			buffer = @_context.buffer
 
-			original_length = target.length
+			original_length = buffer.length
 			content = yield(*args)
-			__text__(content) if original_length == target.length
+			__text__(content) if original_length == buffer.length
 
 			nil
 		end


### PR DESCRIPTION
If we're going to do selective rendering with a target ID, we should rename the buffer to something other than `target`.