### PR TITLE
Non-breaking Public Context

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -2,15 +2,17 @@
 
 # @api private
 class Phlex::Context
-	def initialize
+	def initialize(user_context = {})
 		@buffer = +""
 		@capturing = false
+		@user_context = user_context
 		@fragment = nil
 		@in_target_fragment = false
 		@found_target_fragment = false
 	end
 
-	attr_accessor :buffer, :capturing, :fragment, :in_target_fragment, :found_target_fragment
+	attr_accessor :buffer, :capturing, :user_context, :fragment,
+		:in_target_fragment, :found_target_fragment
 
 	# Added for backwards compatibility with phlex-rails. We can remove this with 2.0
 	def target

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -95,8 +95,8 @@ module Phlex
 		end
 
 		# Renders the view and returns the buffer. The default buffer is a mutable String.
-		def call(buffer = +"", context: Phlex::Context.new, view_context: nil, parent: nil, fragment: nil, &block)
-			__final_call__(buffer, context: context, view_context: view_context, parent: parent, fragment: fragment, &block).tap do
+		def call(...)
+			__final_call__(...).tap do
 				self.class.rendered_at_least_once!
 			end
 		end
@@ -133,6 +133,12 @@ module Phlex
 			end
 
 			buffer << context.buffer unless parent
+		end
+
+		# Access the current render context data
+		# @return the supplied context object, by default a Hash
+		def context
+			@_context.user_context
 		end
 
 		# Output text content. The text will be HTML-escaped.

--- a/test/phlex/view/context.rb
+++ b/test/phlex/view/context.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+describe Phlex::HTML do
+	extend ViewHelper
+
+	let(:context_provider) do
+		Class.new(Phlex::HTML) do
+			def initialize(context)
+				@context = context
+			end
+
+			def view_template
+				prior_values = {}
+				@context.each do |key, value|
+					prior_values[key], context[key] = context[key], value
+				end
+
+				yield
+
+				prior_values.each do |key, value|
+					context[key] = value
+				end
+			end
+		end
+	end
+
+	with "context" do
+		view do
+			def view_template
+				div(class: tokens(-> { context[:theme] == :dark } => { then: "dark", else: "light" }))
+			end
+		end
+
+		let(:output) do
+			context_provider.new(ctx).call do |component|
+				component.send(:render, view)
+			end
+		end
+
+		with "theme: dark" do
+			let(:ctx) do
+				{ theme: :dark }
+			end
+
+			it "renders with a dark class" do
+				expect(output).to be == %(<div class="dark"></div>)
+			end
+		end
+
+		with "theme: light" do
+			let(:ctx) do
+				{ theme: :light }
+			end
+
+			it "renders with a light class" do
+				expect(output).to be == %(<div class="light"></div>)
+			end
+		end
+	end
+end


### PR DESCRIPTION
This omits a way to set context at the top of the render tree (the initial `call`) but allows you to access and manipulate the context from within any `SGML` component by calling the new `context` method.

For potential usefulness of context, see the original breaking PR #644 