### PR TITLE
Support selecting multiple fragments

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -6,17 +6,32 @@ class Phlex::Context
 		@buffer = +""
 		@capturing = false
 		@user_context = user_context
-		@fragment = nil
+		@fragments = nil
 		@in_target_fragment = false
-		@found_target_fragment = false
 	end
 
-	attr_accessor :buffer, :capturing, :user_context, :fragment,
-		:in_target_fragment, :found_target_fragment
+	attr_accessor :buffer, :capturing, :user_context, :in_target_fragment
+
+	attr_reader :fragments
 
 	# Added for backwards compatibility with phlex-rails. We can remove this with 2.0
 	def target
 		@buffer
+	end
+
+	def target_fragments(fragments)
+		@fragments = fragments.to_h { |it| [it, +""] }
+	end
+
+	def begin_target(id)
+		@in_target_fragment = id
+		@buffer << %(<template data-id="#{id}">)
+	end
+
+	def end_target
+		id = @in_target_fragment
+		@buffer << @fragments.delete(id) << "</template>"
+		@in_target_fragment = false
 	end
 
 	def capturing_into(new_buffer)

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -25,12 +25,10 @@ class Phlex::Context
 
 	def begin_target(id)
 		@in_target_fragment = id
-		@buffer << %(<template data-id="#{id}">)
 	end
 
 	def end_target
 		@fragments.delete(@in_target_fragment)
-		@buffer << "</template>"
 		@in_target_fragment = false
 	end
 

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -20,7 +20,7 @@ class Phlex::Context
 	end
 
 	def target_fragments(fragments)
-		@fragments = fragments.to_h { |it| [it, +""] }
+		@fragments = fragments.to_h { |it| [it, true] }
 	end
 
 	def begin_target(id)
@@ -29,8 +29,8 @@ class Phlex::Context
 	end
 
 	def end_target
-		id = @in_target_fragment
-		@buffer << @fragments.delete(id) << "</template>"
+		@fragments.delete(@in_target_fragment)
+		@buffer << "</template>"
 		@in_target_fragment = false
 	end
 

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -45,17 +45,18 @@ module Phlex::Elements
 
 				context = @_context
 				buffer = context.buffer
-				fragment = context.fragment
-				end_find = false
+				fragment = context.fragments
+				target_found = false
 
 				if fragment
-					in_target_fragment = context.in_target_fragment
+					return if fragment.length == 0 # we found all our fragments already
 
-					if !in_target_fragment
-					  if !context.found_target_fragment && attributes[:id] == fragment
-							context.in_target_fragment = true
-							context.found_target_fragment = true
-							end_find = true
+					id = attributes[:id]
+
+					if !context.in_target_fragment
+					  if fragment[id]
+							context.begin_target(id)
+							target_found = true
 						else
 							yield(self) if block
 							return nil
@@ -83,8 +84,7 @@ module Phlex::Elements
 
 				#{'flush' if tag == 'head'}
 
-				# I think we can actually throw from here.
-				context.in_target_fragment = false if end_find
+				context.end_target if target_found
 
 				nil
 			end
@@ -114,14 +114,17 @@ module Phlex::Elements
 				#{deprecation}
 				context = @_context
 				buffer = context.buffer
-				fragment = context.fragment
+				fragment = context.fragments
 
 				if fragment
-					in_target_fragment = context.in_target_fragment
+					return if fragment.length == 0 # we found all our fragments already
 
-					if !in_target_fragment
-					  if !context.found_target_fragment && attributes[:id] == fragment
-							context.found_target_fragment = true
+					id = attributes[:id]
+
+					if !context.in_target_fragment
+					  if fragment[id]
+							context.begin_target(id)
+							target_found = true
 						else
 							return nil
 						end
@@ -133,6 +136,8 @@ module Phlex::Elements
 				else # without attributes
 					buffer << "<#{tag}>"
 				end
+
+				context.end_target if target_found
 
 				nil
 			end

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -30,7 +30,7 @@ module Phlex
 		# Output an HTML doctype.
 		def doctype
 			context = @_context
-			return if context.fragment && !context.in_target_fragment
+			return if context.fragments && !context.in_target_fragment
 
 			context.buffer << "<!DOCTYPE html>"
 			nil

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -102,12 +102,12 @@ module Phlex
 		end
 
 		# @api private
-		def __final_call__(buffer = +"", context: Phlex::Context.new, view_context: nil, parent: nil, fragment: nil, &block)
+		def __final_call__(buffer = +"", context: Phlex::Context.new, view_context: nil, parent: nil, fragments: nil, &block)
 			@_buffer = buffer
 			@_context = context
 			@_view_context = view_context
 			@_parent = parent
-			@_context.fragment = fragment if fragment
+			@_context.target_fragments(fragments) if fragments
 
 			block ||= @_content_block
 
@@ -147,7 +147,7 @@ module Phlex
 		# @see #format_object
 		def plain(content)
 			context = @_context
-			return if context.fragment && !context.in_target_fragment
+			return if context.fragments && !context.in_target_fragment
 
 			unless __text__(content)
 				raise ArgumentError, "You've passed an object to plain that is not handled by format_object. See https://rubydoc.info/gems/phlex/Phlex/SGML#format_object-instance_method for more information"
@@ -161,7 +161,7 @@ module Phlex
 		# @yield If a block is given, it yields the block with no arguments.
 		def whitespace(&block)
 			context = @_context
-			return if context.fragment && !context.in_target_fragment
+			return if context.fragments && !context.in_target_fragment
 
 			buffer = context.buffer
 
@@ -179,7 +179,7 @@ module Phlex
 		# @return [nil]
 		def comment(&block)
 			context = @_context
-			return if context.fragment && !context.in_target_fragment
+			return if context.fragments && !context.in_target_fragment
 
 			buffer = context.buffer
 
@@ -197,7 +197,7 @@ module Phlex
 			return nil unless content
 
 			context = @_context
-			return if context.fragment && !context.in_target_fragment
+			return if context.fragments && !context.in_target_fragment
 
 			context.buffer << content
 			nil

--- a/test/phlex/selective_rendering.rb
+++ b/test/phlex/selective_rendering.rb
@@ -45,18 +45,18 @@ describe Phlex::HTML do
 	it "renders the just the target fragment" do
 		expect(
 			StandardElementExample.new.call(fragments: ["target"])
-		).to be == %(<template data-id="target"><h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1></template>)
+		).to be == %(<h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1>)
 	end
 
 	it "works with void elements" do
 		expect(
 			VoidElementExample.new.call(fragments: ["target"])
-		).to be == %(<template data-id="target"><img id="target" src="image.jpg"></template>)
+		).to be == %(<img id="target" src="image.jpg">)
 	end
 
 	it "supports multiple fragments" do
 		expect(
 			StandardElementExample.new.call(fragments: ["target", "image"])
-		).to be == %(<template data-id="target"><h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1></template><template data-id="image"><img id="image" src="after.jpg"></template>)
+		).to be == %(<h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1><img id="image" src="after.jpg">)
 	end
 end

--- a/test/phlex/selective_rendering.rb
+++ b/test/phlex/selective_rendering.rb
@@ -14,7 +14,8 @@ class StandardElementExample < Phlex::HTML
 				strong { "World" }
 				img(src: "image.jpg")
 			}
-			img(src: "after.jpg")
+			strong { "Here" }
+			img(id: "image", src: "after.jpg")
 			h1(id: "target") { "After" }
 		}
 	end
@@ -43,13 +44,19 @@ end
 describe Phlex::HTML do
 	it "renders the just the target fragment" do
 		expect(
-			StandardElementExample.new.call(fragment: "target")
-		).to be == %(<h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1>)
+			StandardElementExample.new.call(fragments: ["target"])
+		).to be == %(<template data-id="target"><h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1></template>)
 	end
 
 	it "works with void elements" do
 		expect(
-			VoidElementExample.new.call(fragment: "target")
-		).to be == %(<img id="target" src="image.jpg">)
+			VoidElementExample.new.call(fragments: ["target"])
+		).to be == %(<template data-id="target"><img id="target" src="image.jpg"></template>)
+	end
+
+	it "supports multiple fragments" do
+		expect(
+			StandardElementExample.new.call(fragments: ["target", "image"])
+		).to be == %(<template data-id="target"><h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1></template><template data-id="image"><img id="image" src="after.jpg"></template>)
 	end
 end


### PR DESCRIPTION
This PR adds support for matching multiple fragments. Each fragment is rendered in its own `<template>` with a `data-id` attribute matching the ID of the fragment matched.