### PR TITLE
Introduce Phlex::Bucket

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -16,6 +16,7 @@ module Phlex
 	autoload :BlackHole, "phlex/black_hole"
 	autoload :CSV, "phlex/csv"
 	autoload :Callable, "phlex/callable"
+	autoload :Bucket, "phlex/bucket"
 
 	# Included in all Phlex exceptions allowing you to match any Phlex error.
 	# @example Rescue any Phlex error:

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -6,7 +6,7 @@ module Phlex::Bucket
 
 		return if instance_methods.include?(name)
 
-		if constant < Phlex::SGML
+		if Class === constant && constant < Phlex::SGML
 			define_method(name) do |*args, **kwargs, &block|
 				render constant.new(*args, **kwargs, &block)
 			end

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Phlex::Bucket
+	def const_added(name)
+		constant = const_get(name)
+
+		return if instance_methods.include?(name)
+
+		if constant < Phlex::SGML
+			define_method(name) do |*args, **kwargs, &block|
+				render constant.new(*args, **kwargs, &block)
+			end
+		end
+	end
+end

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -8,7 +8,7 @@ module Phlex::Bucket
 
 		if Class === constant && constant < Phlex::SGML
 			define_method(name) do |*args, **kwargs, &block|
-				render constant.new(*args, **kwargs, &block)
+				render(constant.new(*args, **kwargs), &block)
 			end
 		end
 	end

--- a/test/phlex/bucket.rb
+++ b/test/phlex/bucket.rb
@@ -22,8 +22,11 @@ class Example < Phlex::HTML
 	end
 end
 
-describe Phlex::Bucket do
-	it "works" do
-		expect(Example.new.call).to be == "<h1>Hi Joel</h1>"
+# This feature is only supported in Ruby 3.2 or later.
+if RUBY_VERSION >= "3.2"
+	describe Phlex::Bucket do
+		it "works" do
+			expect(Example.new.call).to be == "<h1Hi Joel</h1>"
+		end
 	end
 end

--- a/test/phlex/bucket.rb
+++ b/test/phlex/bucket.rb
@@ -26,7 +26,7 @@ end
 if RUBY_VERSION >= "3.2"
 	describe Phlex::Bucket do
 		it "works" do
-			expect(Example.new.call).to be == "<h1Hi Joel</h1>"
+			expect(Example.new.call).to be == "<h1>Hi Joel</h1>"
 		end
 	end
 end

--- a/test/phlex/bucket.rb
+++ b/test/phlex/bucket.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Components
+	extend Phlex::Bucket
+
+	class SayHi < Phlex::HTML
+		def initialize(name)
+			@name = name
+		end
+
+		def template
+			h1 { "Hi #{@name}" }
+		end
+	end
+end
+
+class Example < Phlex::HTML
+	include Components
+
+	def template
+		SayHi("Joel")
+	end
+end
+
+describe Phlex::Bucket do
+	it "works" do
+		expect(Example.new.call).to be == "<h1>Hi Joel</h1>"
+	end
+end


### PR DESCRIPTION
`Phlex::Bucket` allows you to define a bucket of components which can then be included into your views and other components.

Here’s how it works:

First, you can define a module to hold your components and have it extend `Phlex::Bucket`. Then define as many components in this module as you like. These should be namespaced directly under your module.

```ruby
module Components
  extend Phlex::Bucket

  class Card < ApplicationComponent
    def template(&)
      article(class: "card", &)
    end
  end
end
```

Then include that module in your base component/view classes.

```ruby
ApplicationComponent.include(Components)
ApplicationView.include(Components)
```

Now you can use components from this bucket by calling their name as a method.

```ruby
class Hello < ApplicationView
  def template
    Card { "Hello" }
  end
end
```

The only real downside to this is all your components need to live in a single namespace. That seems to work okay for React and web components, so maybe it’ll work for you. Of course you can continue to render namespaced components by passing them to `render`.

One gotcha to look out for is if you have a component that takes no arguments, you’ll need to include empty parentheses to tell Ruby this is a method call, not a constant lookup.

You can create and import as many “buckets” as you like, but they can’t have conflicting names, since they all share a single namespace once the methods are included.

### Why can't we do `MyNamespace::Card()`?

Because that would be calling `Card()` on `MyNamespace`, which has no idea which component you’re currently rendering. The only way to support this would be to have a global variable keep track of the currently rendering component, which would be really nasty. When you call `Card()` on `self`, it’s easy to pass the rendering context to the new component.

Update: If you want to know how this could be done ^^ here's a rough sketch. https://github.com/phlex-ruby/phlex/commit/f8cca44a8a537c25e4d88c6a6d1b8b3a4e91db69