### PR TITLE
Halt early when searching for a fragment

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -29,7 +29,11 @@ class Phlex::Context
 
 	def end_target
 		@fragments.delete(@in_target_fragment)
-		@in_target_fragment = false
+		if @fragments.any?
+			@in_target_fragment = false
+		else
+			throw(:phlex_fragment_halt)
+		end
 	end
 
 	def capturing_into(new_buffer)

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -113,22 +113,45 @@ module Phlex
 
 			return "" unless render?
 
-			around_template do
-				if block
-					if is_a?(DeferredRender)
-						__vanish__(self, &block)
-						view_template
-					else
-						view_template do |*args|
-							if args.length > 0
-								yield_content_with_args(*args, &block)
+			if !parent && context.fragments
+				catch(:phlex_fragment_halt) do
+					around_template do
+						if block
+							if is_a?(DeferredRender)
+								__vanish__(self, &block)
+								view_template
 							else
-								yield_content(&block)
+								view_template do |*args|
+									if args.length > 0
+										yield_content_with_args(*args, &block)
+									else
+										yield_content(&block)
+									end
+								end
 							end
+						else
+							view_template
 						end
 					end
-				else
-					view_template
+				end
+			else
+				around_template do
+					if block
+						if is_a?(DeferredRender)
+							__vanish__(self, &block)
+							view_template
+						else
+							view_template do |*args|
+								if args.length > 0
+									yield_content_with_args(*args, &block)
+								else
+									yield_content(&block)
+								end
+							end
+						end
+					else
+						view_template
+					end
 				end
 			end
 
@@ -191,7 +214,7 @@ module Phlex
 		end
 
 		# This method is very dangerous and should usually be avoided. It will output the given String without any HTML safety. You should never use this method to output unsafe user input.
-		# @param content [String|nil]
+		# @param content [String, nil]
 		# @return [nil]
 		def unsafe_raw(content = nil)
 			return nil unless content


### PR DESCRIPTION
This is my attempt to re-apply #671 after the recent changes to fragment searching. Unfortunately, the benchmarks show that this makes fragment searching slower.