### PR TITLE
Eager load bucket constants

### DIFF
--- a/fixtures/components.rb
+++ b/fixtures/components.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Components
+	extend Phlex::Bucket
+
+	autoload :SayHi, "components/say_hi"
+end

--- a/fixtures/components/say_hi.rb
+++ b/fixtures/components/say_hi.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Components::SayHi < Phlex::HTML
+	def initialize(name, times: 1)
+		@name = name
+		@times = times
+	end
+
+	def template
+		article {
+			@times.times { h1 { "Hi #{@name}" } }
+			yield
+		}
+	end
+end

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -4,12 +4,21 @@ module Phlex::Bucket
 	def self.extended(mod)
 		warn "🚨 [WARNING] Phlex::Bucket is experimental and may be removed from future versions of Phlex."
 
-		# Eager load all constants in the module for apps that use autoloading.
+		# Eager load all constants in the module for apps that use Zeitwerk.
 		mod.constants.each { |c| mod.const_get(c) }
 	end
 
 	def const_added(name)
-		constant = const_get(name)
+		# This can sometime be triggered by an autoload, which means it gets
+		# triggered a second time when we call `const_get` below and Ruby loads it.
+		return super if Fiber[:__phlex_adding_bucket_const__]
+
+		begin
+			Fiber[:__phlex_adding_bucket_const__] = true
+			constant = const_get(name)
+		ensure
+			Fiber[:__phlex_adding_bucket_const__] = false
+		end
 
 		if instance_methods.include?(name)
 			raise NameError, "The instance method `#{name}' is already defined on `#{inspect}`."

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 module Phlex::Bucket
-	def self.extended(_)
+	def self.extended(mod)
 		warn "🚨 [WARNING] Phlex::Bucket is experimental and may be removed from future versions of Phlex."
+
+		# Eager load all constants in the module for apps that use autoloading.
+		mod.constants.each { |c| mod.const_get(c) }
 	end
 
 	def const_added(name)

--- a/test/phlex/bucket.rb
+++ b/test/phlex/bucket.rb
@@ -1,22 +1,6 @@
 # frozen_string_literal: true
 
-module Components
-	extend Phlex::Bucket
-
-	class SayHi < Phlex::HTML
-		def initialize(name, times: 1)
-			@name = name
-			@times = times
-		end
-
-		def template
-			article {
-				@times.times { h1 { "Hi #{@name}" } }
-				yield
-			}
-		end
-	end
-end
+require "components"
 
 class Example < Phlex::HTML
 	include Components


### PR DESCRIPTION
When using `Phlex::Buckets` in Rails, Zeitwerk wouldn't load the component constants when only the methods were referenced. This fix ensures all the constants are loaded.