### PR TITLE
Lazy load autoloaded bucket components

### DIFF
--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -1,23 +1,13 @@
 # frozen_string_literal: true
 
 module Phlex::Bucket
-	module Proxy
-		def method_missing(name, *args, **kwargs, &block)
-			if self.class.constants.include?(name) && self.class.const_get(name) && methods.include?(name)
-				public_send(name, *args, **kwargs, &block)
-			else
-				super
-			end
-		end
-
-		def respond_to_missing?(name, include_private = false)
-			self.class.constants.include?(name) && self.class.const_get(name) && methods.include?(name)
-		end
-	end
-
 	def self.extended(mod)
 		warn "🚨 [WARNING] Phlex::Bucket is experimental and may be removed from future versions of Phlex."
-		mod.include(Proxy)
+	end
+
+	# When a bucket is included in a module, we need to load all of its components.
+	def included(mod)
+		constants.each { |c| mod.const_get(c) if autoload?(c) }
 	end
 
 	def method_missing(name, *args, **kwargs, &block)

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -5,37 +5,48 @@ module Phlex::Bucket
 		warn "🚨 [WARNING] Phlex::Bucket is experimental and may be removed from future versions of Phlex."
 
 		# Eager load all constants in the module for apps that use Zeitwerk.
-		mod.constants.each { |c| mod.const_get(c) }
+		mod.constants.each { |c| mod.const_added(c) if mod.autoload?(c) }
 	end
 
 	def const_added(name)
-		# This can sometime be triggered by an autoload, which means it gets
-		# triggered a second time when we call `const_get` below and Ruby loads it.
-		return super if Fiber[:__phlex_adding_bucket_const__]
-
-		begin
-			Fiber[:__phlex_adding_bucket_const__] = true
-			constant = const_get(name)
-		ensure
-			Fiber[:__phlex_adding_bucket_const__] = false
-		end
-
-		if instance_methods.include?(name)
-			raise NameError, "The instance method `#{name}' is already defined on `#{inspect}`."
-		elsif methods.include?(name)
-			raise NameError, "The method `#{name}' is already defined on `#{inspect}`."
-		end
-
-		constant.include(self)
-
-		if Class === constant && constant < Phlex::SGML
+		if autoload?(name)
 			define_method(name) do |*args, **kwargs, &block|
-				render(constant.new(*args, **kwargs), &block)
+				this = method(name)
+				self.class.const_get(name) # load the constant (which should override this method)
+
+				if this == method(name)
+					# loading the constant didn't override this method
+					super
+				else
+					public_send(name, *args, **kwargs, &block) # call this method again
+				end
 			end
 
 			define_singleton_method(name) do |*args, **kwargs, &block|
-				Fiber[:__phlex_component__].instance_exec do
+				this = method(name)
+				const_get(name) # load the constant (which should override this method)
+
+				if this == method(name)
+					# loading the constant didn't override this method
+					super
+				else
+					public_send(name, *args, **kwargs, &block) # call this method again
+				end
+			end
+		else
+			constant = const_get(name)
+
+			constant.include(self)
+
+			if Class === constant && constant < Phlex::SGML
+				define_method(name) do |*args, **kwargs, &block|
 					render(constant.new(*args, **kwargs), &block)
+				end
+
+				define_singleton_method(name) do |*args, **kwargs, &block|
+					Fiber[:__phlex_component__].instance_exec do
+						render(constant.new(*args, **kwargs), &block)
+					end
 				end
 			end
 		end

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -1,52 +1,60 @@
 # frozen_string_literal: true
 
 module Phlex::Bucket
+	module Proxy
+		def method_missing(name, *args, **kwargs, &block)
+			return super unless self.class.constants.include?(name)
+			constant = self.class.const_get(name)
+
+			if methods.include?(name)
+				public_send(name, *args, **kwargs, &block)
+			else
+				super
+			end
+		end
+	end
+
 	def self.extended(mod)
 		warn "🚨 [WARNING] Phlex::Bucket is experimental and may be removed from future versions of Phlex."
+		mod.include(Proxy)
+	end
 
-		# Eager load all constants in the module for apps that use Zeitwerk.
-		mod.constants.each { |c| mod.const_added(c) if mod.autoload?(c) }
+	def method_missing(name, *args, **kwargs, &block)
+		return super unless constants.include?(name)
+		constant = const_get(name)
+
+		if methods.include?(name)
+			public_send(name, *args, **kwargs, &block)
+		else
+			super
+		end
+	end
+
+	def respond_to_missing?(name, include_private = false)
+		autoload?(name) || super
 	end
 
 	def const_added(name)
-		if autoload?(name)
-			define_method(name) do |*args, **kwargs, &block|
-				this = method(name)
-				self.class.const_get(name) # load the constant (which should override this method)
+		return if autoload?(name)
 
-				if this == method(name)
-					# loading the constant didn't override this method
-					super
-				else
-					public_send(name, *args, **kwargs, &block) # call this method again
-				end
+		constant = const_get(name)
+
+		if instance_methods.include?(name)
+			raise NameError, "The instance method `#{name}' is already defined on `#{inspect}`."
+		elsif methods.include?(name)
+			raise NameError, "The method `#{name}' is already defined on `#{inspect}`."
+		end
+
+		constant.include(self)
+
+		if Class === constant && constant < Phlex::SGML
+			define_method(name) do |*args, **kwargs, &block|
+				render(constant.new(*args, **kwargs), &block)
 			end
 
 			define_singleton_method(name) do |*args, **kwargs, &block|
-				this = method(name)
-				const_get(name) # load the constant (which should override this method)
-
-				if this == method(name)
-					# loading the constant didn't override this method
-					super
-				else
-					public_send(name, *args, **kwargs, &block) # call this method again
-				end
-			end
-		else
-			constant = const_get(name)
-
-			constant.include(self)
-
-			if Class === constant && constant < Phlex::SGML
-				define_method(name) do |*args, **kwargs, &block|
+				Fiber[:__phlex_component__].instance_exec do
 					render(constant.new(*args, **kwargs), &block)
-				end
-
-				define_singleton_method(name) do |*args, **kwargs, &block|
-					Fiber[:__phlex_component__].instance_exec do
-						render(constant.new(*args, **kwargs), &block)
-					end
 				end
 			end
 		end

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -3,11 +3,13 @@
 module Phlex::Bucket
 	def self.extended(mod)
 		warn "🚨 [WARNING] Phlex::Bucket is experimental and may be removed from future versions of Phlex."
+		super
 	end
 
 	# When a bucket is included in a module, we need to load all of its components.
 	def included(mod)
 		constants.each { |c| mod.const_get(c) if autoload?(c) }
+		super
 	end
 
 	def method_missing(name, *args, **kwargs, &block)
@@ -19,7 +21,11 @@ module Phlex::Bucket
 	end
 
 	def respond_to_missing?(name, include_private = false)
-		constants.include?(name) && const_get(name) && methods.include?(name)
+		if name[0] == name[0].upcase && constants.include?(name) && const_get(name) && methods.include?(name)
+			true
+		else
+			super
+		end
 	end
 
 	def const_added(name)
@@ -46,5 +52,7 @@ module Phlex::Bucket
 				end
 			end
 		end
+
+		super
 	end
 end

--- a/lib/phlex/bucket.rb
+++ b/lib/phlex/bucket.rb
@@ -3,14 +3,15 @@
 module Phlex::Bucket
 	module Proxy
 		def method_missing(name, *args, **kwargs, &block)
-			return super unless self.class.constants.include?(name)
-			constant = self.class.const_get(name)
-
-			if methods.include?(name)
+			if self.class.constants.include?(name) && self.class.const_get(name) && methods.include?(name)
 				public_send(name, *args, **kwargs, &block)
 			else
 				super
 			end
+		end
+
+		def respond_to_missing?(name, include_private = false)
+			self.class.constants.include?(name) && self.class.const_get(name) && methods.include?(name)
 		end
 	end
 
@@ -20,10 +21,7 @@ module Phlex::Bucket
 	end
 
 	def method_missing(name, *args, **kwargs, &block)
-		return super unless constants.include?(name)
-		constant = const_get(name)
-
-		if methods.include?(name)
+		if constants.include?(name) && const_get(name) && methods.include?(name)
 			public_send(name, *args, **kwargs, &block)
 		else
 			super
@@ -31,7 +29,7 @@ module Phlex::Bucket
 	end
 
 	def respond_to_missing?(name, include_private = false)
-		autoload?(name) || super
+		constants.include?(name) && const_get(name) && methods.include?(name)
 	end
 
 	def const_added(name)


### PR DESCRIPTION
Autoloaded Ruby constants will not have corresponding proxy methods on Buckets, since these methods are defined on `const_added`. This PR solves that in two ways:

### External access
Assuming a runtime environment where none of the constants are loaded by default — such as Rails with Zeitwerk during development — we use a bucket like this:

```ruby
def view_template
  Components::Heading { "Hello" }
end
```

This call will autoload the `Components` module, but it will not autoload the `Components::Heading` module, since it’s just a method call on `Components`. How we handle this is the `Components` bucket catches the call with `method_missing`, and then tries to load the constant. If loading the constant is successful, it can call the newly defined `Heading` method on `Components`.

### When included
If we include `Components` and then try to call `Heading`, again we will run into the same problem.

```ruby
class MyComponent < Phlex::HTML
  include Components

  def view_template
    Heading { "Hello" }
  end
end
```

In this case, though, we can’t use `method_missing`. If you include `Components` and `AnotherBucket` and they both define a `Heading` component, you would expect `AnotherBucket`’s `Heading` component to take precedence over `Components`’ `Heading` component. If both buckets were using the `method_missing` technique, this precedence would be based on which bucket had their component autoloaded first.

So instead, when you _include_ a bucket, we eager-load all that bucket’s components.