### PR TITLE
Improve performance by flushing regularly

### DIFF
--- a/fixtures/page.rb
+++ b/fixtures/page.rb
@@ -6,26 +6,28 @@ module Example
 			render LayoutComponent.new do
 				h1 { "Hi" }
 
-				table id: "test", class: "a b c d e f g" do
-					tr do
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
-						end
+				100.times do
+					table id: "test", class: "a b c d e f g" do
+						tr do
+							td id: "test", class: "a b c d e f g" do
+								span { "Hi" }
+							end
 
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
-						end
+							td id: "test", class: "a b c d e f g" do
+								span { "Hi" }
+							end
 
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
-						end
+							td id: "test", class: "a b c d e f g" do
+								span { "Hi" }
+							end
 
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
-						end
+							td id: "test", class: "a b c d e f g" do
+								span { "Hi" }
+							end
 
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
+							td id: "test", class: "a b c d e f g" do
+								span { "Hi" }
+							end
 						end
 					end
 				end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -9,11 +9,16 @@ class Phlex::Context
 		@fragments = nil
 		@in_target_fragment = false
 		@halt_signal = nil
+		@element_count = 0
 	end
 
 	attr_accessor :buffer, :capturing, :user_context, :in_target_fragment
 
 	attr_reader :fragments
+
+	def bump
+		@element_count += 1
+	end
 
 	# Added for backwards compatibility with phlex-rails. We can remove this with 2.0
 	def target

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -82,7 +82,8 @@ module Phlex::Elements
 					end
 				end
 
-				#{'flush' if tag == 'head'}
+				element_count = context.bump
+				flush if (element_count % 9) == 0
 
 				context.end_target if target_found
 


### PR DESCRIPTION
Turns out reading the length of a string that’s been mutated gets slower the larger the string gets. This PR makes Phlex regularly flush the internal buffer to the external buffer, which means when `yield_content` calls `.length` on the internal buffer, it’s always quite small.

**Before:**
```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
Warming up --------------------------------------
                Page    73.000 i/100ms
Calculating -------------------------------------
                Page    736.710 (± 0.8%) i/s -      3.723k in   5.053928s
```

**After:**
```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
Warming up --------------------------------------
                Page   399.000 i/100ms
Calculating -------------------------------------
                Page      3.977k (± 0.9%) i/s -     19.950k in   5.017126s
```