### PR TITLE
Fix for components that render content before a fragment is found

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -158,9 +158,6 @@ module Phlex
 		# @return [nil]
 		# @see #format_object
 		def plain(content)
-			context = @_context
-			return if context.fragments && !context.in_target_fragment
-
 			unless __text__(content)
 				raise ArgumentError, "You've passed an object to plain that is not handled by format_object. See https://rubydoc.info/gems/phlex/Phlex/SGML#format_object-instance_method for more information"
 			end
@@ -337,7 +334,7 @@ module Phlex
 
 			original_length = buffer.bytesize
 			content = yield(self)
-			plain(content) if original_length == buffer.bytesize
+			__text__(content) if original_length == buffer.bytesize
 
 			nil
 		end
@@ -351,7 +348,7 @@ module Phlex
 
 			original_length = buffer.bytesize
 			content = yield
-			plain(content) if original_length == buffer.bytesize
+			__text__(content) if original_length == buffer.bytesize
 
 			nil
 		end
@@ -366,7 +363,7 @@ module Phlex
 
 			original_length = buffer.bytesize
 			content = yield(*args)
-			plain(content) if original_length == buffer.bytesize
+			__text__(content) if original_length == buffer.bytesize
 
 			nil
 		end
@@ -374,6 +371,9 @@ module Phlex
 		# Performs the same task as the public method #plain, but does not raise an error if an unformattable object is passed
 		# @api private
 		def __text__(content)
+			context = @_context
+			return true if context.fragments && !context.in_target_fragment
+
 			case content
 			when String
 				@_context.buffer << Phlex::Escape.html_escape(content)

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -337,7 +337,7 @@ module Phlex
 
 			original_length = buffer.bytesize
 			content = yield(self)
-			__text__(content) if original_length == buffer.bytesize
+			plain(content) if original_length == buffer.bytesize
 
 			nil
 		end
@@ -351,7 +351,7 @@ module Phlex
 
 			original_length = buffer.bytesize
 			content = yield
-			__text__(content) if original_length == buffer.bytesize
+			plain(content) if original_length == buffer.bytesize
 
 			nil
 		end
@@ -366,7 +366,7 @@ module Phlex
 
 			original_length = buffer.bytesize
 			content = yield(*args)
-			__text__(content) if original_length == buffer.bytesize
+			plain(content) if original_length == buffer.bytesize
 
 			nil
 		end

--- a/test/phlex/selective_rendering.rb
+++ b/test/phlex/selective_rendering.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ExampleComponent < Phlex::HTML
-	def view_template(&)
-		div(&)
+	def view_template(&block)
+		div(&block)
 	end
 end
 

--- a/test/phlex/selective_rendering.rb
+++ b/test/phlex/selective_rendering.rb
@@ -6,7 +6,6 @@ class ExampleComponent < Phlex::HTML
 	end
 end
 
-
 class StandardElementExample < Phlex::HTML
 	def initialize(execution_checker = -> {})
 		@execution_checker = execution_checker

--- a/test/phlex/selective_rendering.rb
+++ b/test/phlex/selective_rendering.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+class ExampleComponent < Phlex::HTML
+	def view_template(&)
+		div(&)
+	end
+end
+
+
 class StandardElementExample < Phlex::HTML
 	def initialize(execution_checker = -> {})
 		@execution_checker = execution_checker
@@ -11,6 +18,7 @@ class StandardElementExample < Phlex::HTML
 			comment { h1(id: "target") }
 			h1 { "Before" }
 			img(src: "before.jpg")
+			render ExampleComponent.new { "Should not render" }
 			whitespace
 			comment { "This is a comment" }
 			h1(id: "target") {


### PR DESCRIPTION
Fixes the issue described https://github.com/phlex-ruby/phlex-rails/issues/174#issuecomment-2015516273

I was seeing text output before a `<turbo-frame>` in my responses, and it was all from components that render the text "implicitly".

I found no performance difference with these changes.