### PR TITLE
A `<marquee>` feature for 1.10

### DIFF
--- a/lib/phlex/html/standard_elements.rb
+++ b/lib/phlex/html/standard_elements.rb
@@ -382,6 +382,13 @@ module Phlex::HTML::StandardElements
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/mark
 	register_element :mark
 
+	# @!method marquee(**attributes, &content)
+	# 	Outputs a `<marquee>` tag.
+	# 	@return [nil]
+	#   @yieldparam component [self]
+	#   @see https://developer.mozilla.org/docs/Web/HTML/Element/marquee
+	register_element :marquee
+
 	# @!method menu(**attributes, &content)
 	# 	Outputs a `<menu>` tag.
 	# 	@return [nil]


### PR DESCRIPTION
I was tossing and turning last night because I knew the release of 1.10 was coming up, but I was disappointed that we didn't have a really huge feature for it.

I mean, sure, there's that [nice performance improvement](https://github.com/phlex-ruby/phlex/pull/690) @davekaro contributed that allows Phlex to render at 1.4 Gbps on an M3 chip.

And there is also [that new `Phlex::Kit` feature](https://github.com/phlex-ruby/phlex/pull/674) that @joeldrapper cooked up that makes it easier than ever to render component. You don't even have to say `render` now!

And I guess we also are adding CSV rendering support with `Phlex::CSV`, which improves our output format rendering capacity by 33.3%.

And those are cool and all, but there's just no big... marquee feature, you know? Something that stands out above the rest and declares "This is why this release is happening NOW".

Well, I think I may have found it. The year was 1995, and Internet Explorer 2 was about to release. But they also were missing a standout feature to commemorate their version change achievement.[^1] What was their solution? The `<marquee>` element! 

[^1]: I have taken some liberties with the history here, as I was two years old at the time and not actively subscribed to any web standards mailing lists.

So we too can follow in the inimitable footsteps of the Internet Explorer team. We can add support for the `<marquee>` element in Phlex! We can become true internet explorers ourselves!

```rb
def view_template
  header do
    marquee { "Phlex 1.10 has arrived!" }
    time(datetime: "2024-04-01") { "April 1, 2024" }
  end

  main do
    # TODO: write announcement
  end
end
```

