### PR TITLE
Restore `mix` functionality when the mixed values are nil

### DIFF
--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -72,6 +72,8 @@ module Phlex::Helpers
 	def mix(*args)
 		args.each_with_object({}) do |object, result|
 			result.merge!(object) do |_key, old, new|
+				next new if old.nil?
+
 				case new
 				when Hash
 					old.is_a?(Hash) ? mix(old, new) : new
@@ -93,6 +95,8 @@ module Phlex::Helpers
 					end
 				when String
 					old.is_a?(String) ? "#{old} #{new}" : old + old.class[new]
+				when nil
+					old
 				else
 					new
 				end

--- a/test/phlex/view/mix.rb
+++ b/test/phlex/view/mix.rb
@@ -70,4 +70,14 @@ describe Phlex::Helpers do
 
 		expect(output).to be == { class: ["foo", "bar"] }
 	end
+
+	it "gracefully handles mixing with nils" do
+		output = mix({ class: "foo" }, { class: nil })
+
+		expect(output).to be == { class: "foo" }
+
+		output = mix({ class: nil }, { class: "foo" })
+
+		expect(output).to be == { class: "foo" }
+	end
 end


### PR DESCRIPTION
`mix` used to work intuitively with nil values, but it got broken in my #613 PR.

This adds a test case for the broken functionality and a fix.