### PR TITLE
Quoted escapes

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -393,9 +393,9 @@ module Phlex
 				when true
 					buffer << " " << name
 				when String
-					buffer << " " << name << '="' << Phlex::Escape.html_escape(v) << '"'
+					buffer << " " << name << '="' << v.gsub('"', "&quot;") << '"'
 				when Symbol
-					buffer << " " << name << '="' << Phlex::Escape.html_escape(v.name) << '"'
+					buffer << " " << name << '="' << v.name.gsub('"', "&quot;") << '"'
 				when Integer, Float
 					buffer << " " << name << '="' << v.to_s << '"'
 				when Hash
@@ -408,9 +408,9 @@ module Phlex
 						}, buffer
 					)
 				when Array
-					buffer << " " << name << '="' << Phlex::Escape.html_escape(v.compact.join(" ")) << '"'
+					buffer << " " << name << '="' << v.compact.join(" ").gsub('"', "&quot;") << '"'
 				when Set
-					buffer << " " << name << '="' << Phlex::Escape.html_escape(v.to_a.compact.join(" ")) << '"'
+					buffer << " " << name << '="' << v.to_a.compact.join(" ").gsub('"', "&quot;") << '"'
 				else
 					value = if v.respond_to?(:to_phlex_attribute_value)
 						v.to_phlex_attribute_value
@@ -420,7 +420,7 @@ module Phlex
 						v.to_s
 					end
 
-					buffer << " " << name << '="' << Phlex::Escape.html_escape(value) << '"'
+					buffer << " " << name << '="' << value.gsub('"', "&quot;") << '"'
 				end
 			end
 

--- a/test/phlex/view/capture.rb
+++ b/test/phlex/view/capture.rb
@@ -92,13 +92,13 @@ describe Phlex::HTML do
 		end
 
 		it "should contain the full capture" do
-			expect(example.call(view_context: self)).to be == %(<h1>Before</h1><iframe srcdoc="&lt;h1&gt;Hello&lt;/h1&gt;&lt;h1&gt;World&lt;/h1&gt;"></iframe><h1>After</h1>)
+			expect(example.call(view_context: self)).to be == %(<h1>Before</h1><iframe srcdoc="<h1>Hello</h1><h1>World</h1>"></iframe><h1>After</h1>)
 		end
 
 		it "should contain the full capture if the buffer is provided" do
 			my_buffer = +""
 			example.call(my_buffer, view_context: self)
-			expect(my_buffer).to be == %(<h1>Before</h1><iframe srcdoc="&lt;h1&gt;Hello&lt;/h1&gt;&lt;h1&gt;World&lt;/h1&gt;"></iframe><h1>After</h1>)
+			expect(my_buffer).to be == %(<h1>Before</h1><iframe srcdoc="<h1>Hello</h1><h1>World</h1>"></iframe><h1>After</h1>)
 		end
 	end
 end

--- a/test/phlex/view/naughty_business.rb
+++ b/test/phlex/view/naughty_business.rb
@@ -53,7 +53,7 @@ describe Phlex::HTML do
 		end
 
 		it "escapes the attributes" do
-			expect(output).to be == %(<article id="&quot;&gt;&lt;script type=&quot;text/javascript&quot; src=&quot;bad_script.js&quot;&gt;&lt;/script&gt;"></article>)
+			expect(output).to be == %(<article id="&quot;><script type=&quot;text/javascript&quot; src=&quot;bad_script.js&quot;></script>"></article>)
 		end
 	end
 


### PR DESCRIPTION
If I’m not mistaken, the only thing we need to escape inside a double-quoted attribute value is double-quotes.

This is a potential solution to #708 because it would allow for the use of `'`, `<`, `>` and `&` in attribute values, while still replacing `"` with `&quot;` so the value cannot escape.

Closes #708 