### PR TITLE
Exclude quickdraw tests from releases

### DIFF
--- a/phlex.gemspec
+++ b/phlex.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 	# The `git ls-files -z` loads the files in the RubyGem that have been added into git.
 	spec.files = Dir.chdir(File.expand_path(__dir__)) do
 		`git ls-files -z`.split("\x0").reject do |f|
-			(f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+			(f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features|quickdraw)/|\.(?:git|travis|circleci)|appveyor)})
 		end
 	end
 	spec.require_paths = ["lib"]


### PR DESCRIPTION
I was checking the structure of the gemspec, and noticed that it does not have the quickdraw test files in the regex for files that are excluded. 

I did some additional digging and it seems like we could also ignore these:

* fixtures/
* config/
* bench.rb

Let me know what you think, happy to add a commit to add those. 