### PR TITLE
Prefer `delete` to `tr` when using it to remove characters from a string

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -382,10 +382,10 @@ module Phlex
 				end
 
 				lower_name = name.downcase
-				next if lower_name == "href" && v.to_s.downcase.tr("^a-z:",	"").start_with?("javascript:")
+				next if lower_name == "href" && v.to_s.downcase.delete("^a-z:").start_with?("javascript:")
 
 				# Detect unsafe attribute names. Attribute names are considered unsafe if they match an event attribute or include unsafe characters.
-				if HTML::EVENT_ATTRIBUTES.include?(lower_name.tr("^a-z-", "")) || name.match?(/[<>&"']/)
+				if HTML::EVENT_ATTRIBUTES.include?(lower_name.delete("^a-z-")) || name.match?(/[<>&"']/)
 					raise ArgumentError, "Unsafe attribute name detected: #{k}."
 				end
 


### PR DESCRIPTION
After doing some benchmarking, it looks like `delete` is about 19% faster than `tr` when removing characters from a string.

```rb
test_string = "this is the test string"

Benchmark.ips do |x|
  x.report("tr") do
    test_string.tr(" ", "")
  end

  x.report("delete") do
    test_string.delete(" ")
  end
end
```
```
Calculating -------------------------------------
          tr      6.367M (± 3.4%) i/s -     31.997M in   5.032180s
      delete      7.567M (± 6.0%) i/s -     38.022M in   5.053830s

Comparison:
      delete:  7566538.8 i/s
          tr:  6366671.2 i/s - 1.19x  slower
```