### PR TITLE
Support for boolean attributes

### DIFF
--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -32,11 +32,12 @@ module Phlex::Elements
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 
-			def #{method_name}(**attributes, &block)
+			def #{method_name}(*boolean_attributes, **attributes, &block)
 				context = @_context
 				buffer = context.buffer
 				fragment = context.fragments
 				target_found = false
+				attributes.merge!(Hash[boolean_attributes.map { |attribute| [attribute, true] }]) if boolean_attributes.any?
 
 				if fragment
 					return if fragment.length == 0 # we found all our fragments already

--- a/quickdraw/html/boolean_attributes.test.rb
+++ b/quickdraw/html/boolean_attributes.test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class BooleanAttribute < Phlex::HTML
+	def view_template
+		button(:disabled, type: "button") { "Disabled button" }
+	end
+end
+
+class BooleanAndStandardAttribute < Phlex::HTML
+	def view_template
+		button(:disabled, disabled: true, type: "button") { "Disabled button" }
+	end
+end
+
+test "boolean attributes are supported" do
+	expect(BooleanAttribute.call) == "<button type=\"button\" disabled>Disabled button</button>"
+end
+
+test "using boolean attributes and standard attributes do not conflict" do
+	expect(BooleanAndStandardAttribute.call) == "<button disabled type=\"button\">Disabled button</button>"
+end


### PR DESCRIPTION
A neat feature of HTML is being able to use attributes without values to specify functionality:

```html
<button type="button" disabled>Disabled button</button>
<input type="text" required>
```

I thought it might be neat if Phlex supported something similar by allowing positional attributes to act as boolean attributes. The positional attributes are merged with the keyword attributes with a value of `true`, which looks like:

```ruby
button(:disabled, type: 'button') { 'Disabled button' }
# Output: <button type="button" disabled>Disabled button</button>

input(:required, type: 'text')
# Output: <input type="text" required>

div(:any, :symbol, :or, 'string', :can, :go, :here) { 'Content' }
# Output: <div any symbol or string can go here>Content</div>
```

This is particularly useful when using custom element libraries that make extensive use of boolean attributes, such as [Shoelace](https://shoelace.style):

```rb
# Before:
sl_button(disabled: true, loading: true, outline: true, pill: true) { 'Click me' }

# After:
sl_button(:disabled, :loading, :outline, :pill) { 'Click me' }
```