### PR TITLE
Pass args to the block when capturing

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -193,10 +193,14 @@ module Phlex
 		# Capture a block of output as a String.
 		# @note This only works if the block's receiver is the current component or the block returns a String.
 		# @return [String]
-		def capture(&block)
+		def capture(*args, &block)
 			return "" unless block
 
-			@_context.capturing_into(+"") { yield_content(&block) }
+			if args.length > 0
+				@_context.capturing_into(+"") { yield_content_with_args(*args, &block) }
+			else
+				@_context.capturing_into(+"") { yield_content(&block) }
+			end
 		end
 
 		private

--- a/quickdraw/sgml/capture.test.rb
+++ b/quickdraw/sgml/capture.test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ExampleCaptureWithArguments < Phlex::HTML
+	def view_template(&block)
+		h1 { capture("a", "b", "c", &block) }
+	end
+end
+
+test "arguments are passed to the capture block" do
+	output = ExampleCaptureWithArguments.new.call do |a, b, c|
+		"#{a} #{b} #{c}"
+	end
+
+	expect(output) == "<h1>a b c</h1>"
+end


### PR DESCRIPTION
When capturing a block, the arguments should be passed along. This is the first step towards fixing the issue with view component yields.