### PR TITLE
Allow binding to  via the  kwarg in tokens

### DIFF
--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -18,7 +18,7 @@ module Phlex::Helpers
 	# 	tokens(
 	# 		active?: { then: "active", else: "inactive" }
 	# 	)
-	def tokens(*tokens, **conditional_tokens)
+	def tokens(*tokens, class: nil, **conditional_tokens)
 		conditional_tokens.each do |condition, token|
 			truthy = case condition
 				when Symbol then send(condition)
@@ -36,6 +36,13 @@ module Phlex::Helpers
 					when Hash then __append_token__(tokens, token[:else])
 				end
 			end
+		end
+
+		case binding.local_variable_get(:class)
+		when Class
+			raise ArgumentError, "Implicit class binding is not supported. Use the class: keyword argument."
+		else
+			tokens.append binding.local_variable_get(:class)
 		end
 
 		tokens = tokens.select(&:itself).join(" ")

--- a/test/phlex/view/tokens.rb
+++ b/test/phlex/view/tokens.rb
@@ -3,6 +3,41 @@
 describe Phlex::HTML do
 	extend ViewHelper
 
+	with "implicit class binding" do
+		with "class: keyword argument" do
+			view do
+				def view_template
+					red(class: "buzz")
+				end
+
+				def red(class:)
+					div(class: tokens("fizz", class:))
+				end
+			end
+
+			it "implicitly binds class: keyword argument" do
+				expect(output).to be == %(<div class="fizz buzz"></div>)
+			end
+		end
+
+		with "endless argumens (...)" do
+			view do
+				def view_template
+					red(class: "buzz")
+				end
+
+				def red(...)
+					div(class: tokens("fizz", class:))
+				end
+			end
+
+			it "raises error" do
+				expect{ output }.to raise_exception ArgumentError,
+					message: be == "Implicit class binding is not supported. Use the class: keyword argument."
+			end
+		end
+	end
+
 	with "conditional classes" do
 		with "symbol conditionals" do
 			view do


### PR DESCRIPTION
This commit provides a shortcut for binding to a `class` keyword argument and passing it into tokens, like this:

```ruby
def view_template
  red(class: "buzz")
end

def red(class:)
  div(class: tokens("fizz", class:))
end
```

Prior to this commit, I'd have to manually bind to the `class` keyword argument passed into tokens like this:

```ruby
def red(class:)
  div(class: tokens("fizz", binding.local_variable_get(:class)))
end
```