### PR TITLE
Add Phlex::SGML::SafeValue to require people to mark attribute values as 'safe' for use in attributes

### DIFF
--- a/lib/phlex/sgml/safe_value.rb
+++ b/lib/phlex/sgml/safe_value.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# @api private
+class Phlex::SGML::SafeValue
+  def initialize(value)
+    @value = value
+  end
+
+  def safe? = true
+  def safe_value = @value
+end

--- a/test/phlex/view/naughty_business.rb
+++ b/test/phlex/view/naughty_business.rb
@@ -70,6 +70,20 @@ describe Phlex::HTML do
 					message: be == "Unsafe attribute name detected: #{event_attribute}."
 			end
 		end
+
+		with "with safe #{event_attribute} attribute" do
+			safe_attributes = { event_attribute => Phlex::SGML::SafeValue.new("alert(1);") }
+
+			view do
+				define_method :view_template do
+					send(:div, **safe_attributes)
+				end
+			end
+
+			it "outputs safe value" do
+				expect(output).to be == "<div #{event_attribute}=\"alert(1);\"></div>"
+			end
+		end
 	end
 
 	%w[< > & " '].each do |naughty_character|


### PR DESCRIPTION
This PR will make it possible to mark values as "safe" to use within "dangerous" Phlex attributes like `onclick`, etc.

It accomplishes this by wrapping a value in a `Phlex::SGML::SafeValue.new("alert('1');")` class and passing it through the Phlex attribute builder. Phlex then detects this class type and passes the string through to the attribute, unescaped.