### PR TITLE
Fix component kit autoload order bug

### DIFF
--- a/fixtures/components.rb
+++ b/fixtures/components.rb
@@ -4,4 +4,5 @@ module Components
 	extend Phlex::Kit
 
 	autoload :SayHi, "components/say_hi"
+	autoload :Article, "components/article"
 end

--- a/fixtures/components/article.rb
+++ b/fixtures/components/article.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Components::Article < Phlex::HTML
+	def template(&block)
+		article(&block)
+	end
+end

--- a/fixtures/components/say_hi.rb
+++ b/fixtures/components/say_hi.rb
@@ -7,7 +7,7 @@ class Components::SayHi < Phlex::HTML
 	end
 
 	def template
-		article {
+		Article {
 			@times.times { h1 { "Hi #{@name}" } }
 			yield
 		}

--- a/lib/phlex/kit.rb
+++ b/lib/phlex/kit.rb
@@ -3,12 +3,23 @@
 module Phlex::Kit
 	def self.extended(mod)
 		warn "⚠️ [WARNING] Phlex::Kit is experimental and may be removed from future versions of Phlex."
-		super
-	end
 
-	# When a kit is included in a module, we need to load all of its components.
-	def included(mod)
-		constants.each { |c| const_get(c) if autoload?(c) }
+		mod.define_method(:respond_to_missing?) do |name, _include_private = false|
+			if name[0] == name[0].upcase && mod.constants.include?(name) && mod.const_get(name) && methods.include?(name)
+				true
+			else
+				super
+			end
+		end
+
+		mod.define_method(:method_missing) do |name, *args, **kwargs, &block|
+			if name[0] == name[0].upcase && mod.constants.include?(name) && mod.const_get(name) && methods.include?(name)
+				public_send(name, *args, **kwargs, &block)
+			else
+				super
+			end
+		end
+
 		super
 	end
 

--- a/lib/phlex/kit.rb
+++ b/lib/phlex/kit.rb
@@ -1,42 +1,39 @@
 # frozen_string_literal: true
 
 module Phlex::Kit
-	def self.extended(mod)
-		warn "⚠️ [WARNING] Phlex::Kit is experimental and may be removed from future versions of Phlex."
-
-		mod.define_method(:respond_to_missing?) do |name, _include_private = false|
-			if name[0] == name[0].upcase && mod.constants.include?(name) && mod.const_get(name) && methods.include?(name)
-				true
-			else
-				super
-			end
-		end
-
-		mod.define_method(:method_missing) do |name, *args, **kwargs, &block|
-			if name[0] == name[0].upcase && mod.constants.include?(name) && mod.const_get(name) && methods.include?(name)
+	module LazyLoader
+		def method_missing(name, *args, **kwargs, &block)
+			if name[0] == name[0].upcase && __phlex_kit_constants__.include?(name) && __get_phlex_kit_constant__(name) && methods.include?(name)
 				public_send(name, *args, **kwargs, &block)
 			else
 				super
 			end
 		end
 
-		super
-	end
-
-	def method_missing(name, *args, **kwargs, &block)
-		if name[0] == name[0].upcase && constants.include?(name) && const_get(name) && methods.include?(name)
-			public_send(name, *args, **kwargs, &block)
-		else
-			super
+		def respond_to_missing?(name, include_private = false)
+			if name[0] == name[0].upcase && __phlex_kit_constants__.include?(name) && __get_phlex_kit_constant__(name) && methods.include?(name)
+				true
+			else
+				super
+			end
 		end
 	end
 
-	def respond_to_missing?(name, include_private = false)
-		if name[0] == name[0].upcase && constants.include?(name) && const_get(name) && methods.include?(name)
-			true
-		else
-			super
-		end
+	include LazyLoader
+
+	def self.extended(mod)
+		warn "⚠️ [WARNING] Phlex::Kit is experimental and may be removed from future versions of Phlex."
+		mod.include(LazyLoader)
+		mod.define_method(:__phlex_kit_constants__) { mod.__phlex_kit_constants__ }
+		mod.define_method(:__get_phlex_kit_constant__) { |name| mod.__get_phlex_kit_constant__(name) }
+	end
+
+	def __phlex_kit_constants__
+		constants
+	end
+
+	def __get_phlex_kit_constant__(name)
+		const_get(name)
 	end
 
 	def const_added(name)


### PR DESCRIPTION
Instead of loading all the constants, now we use method missing to lazy-load them.

I believe this fixes #727 