### PR TITLE
Warn on double render

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -105,6 +105,11 @@ module Phlex
 			@_context = context
 			@_view_context = view_context
 			@_parent = parent
+			if @_rendered
+			  warn "⚠️ [WARNING] You are rendering a component #{self.class.name} twice. This is not supported in Phlex 2.0."
+			  @_rendered = true
+			end
+
 			if fragments
 				warn "⚠️ [WARNING] Selective Rendering is experimental, incomplete, and may change in future versions."
 				@_context.target_fragments(fragments)

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -107,8 +107,8 @@ module Phlex
 			@_parent = parent
 			if @_rendered
 			  warn "⚠️ [WARNING] You are rendering a component #{self.class.name} twice. This is not supported in Phlex 2.0."
-			  @_rendered = true
 			end
+	    @_rendered = true
 
 			if fragments
 				warn "⚠️ [WARNING] Selective Rendering is experimental, incomplete, and may change in future versions."


### PR DESCRIPTION
wasn't sure if I should add tests for this. Adds a warning on double render to 1.10 #607 