### PR TITLE
Allow booleans as conditionals in the tokens helper

### DIFF
--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -20,10 +20,11 @@ module Phlex::Helpers
 	# 	)
 	def tokens(*tokens, **conditional_tokens)
 		conditional_tokens.each do |condition, token|
-			truthy = case condition
+  		truthy = case condition
 				when Symbol then send(condition)
 				when Proc then condition.call
-				else raise ArgumentError, "The class condition must be a Symbol or a Proc."
+				when TrueClass, FalseClass then condition
+				else raise ArgumentError, "The class condition must be a Symbol, Proc, TrueClass or FalseClass."
 			end
 
 			if truthy

--- a/test/phlex/view/tokens.rb
+++ b/test/phlex/view/tokens.rb
@@ -44,6 +44,23 @@ describe Phlex::HTML do
 			end
 		end
 
+		with "boolean conditionals" do
+			view do
+				def view_template
+					a href: "/", **classes("a", "b", "c",
+						true => "true",
+						false => "false") do
+						"Home"
+					end
+				end
+			end
+
+			it "works" do
+				expect(output).to be ==
+					%(<a href="/" class="a b c true">Home</a>)
+			end
+		end
+
 		with "negative conditionals" do
 			view do
 				def view_template


### PR DESCRIPTION
Often times I need to conditionally add classes based on a boolean value, and wrapping them in a Proc adds a bit of overhead. I hope it makes sense to allow raw booleans too.

I added a sus test to keep them in line with the other tests for `tokens`. Let me know if I should move it to quickdraw instead.
