### PR TITLE
Add dynamic tag method

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -206,6 +206,38 @@ module Phlex
 			end
 		end
 
+		def tag(name, ...)
+			normalized_name = case name
+				when Symbol then name.name.downcase
+				when String then name.downcase
+				else raise ArgumentError.new("Expected the tag namea as a Symbol or String.")
+			end
+
+			if name == "script"
+				raise ArgumentError.new("You can’t use the `<script>` tag from the `tag` method. Use `unsafe_tag` instead, but be careful if using user input.")
+			end
+
+			if registered_elements[normalized_name]
+				public_send(normalized_name, ...)
+			else
+				raise ArgumentError.new("Unknown tag: #{normalized_name}")
+			end
+		end
+
+		def unsafe_tag(name, ...)
+			normalized_name = case name
+				when Symbol then name.name.downcase
+				when String then name.downcase
+				else raise ArgumentError.new("Expected the tag namea as a Symbol or String.")
+			end
+
+			if registered_elements[normalized_name]
+				public_send(normalized_name, ...)
+			else
+				raise ArgumentError.new("Unknown tag: #{normalized_name}")
+			end
+		end
+
 		private
 
 		# @api private

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -228,7 +228,7 @@ module Phlex
 			normalized_name = case name
 				when Symbol then name.name.downcase
 				when String then name.downcase
-				else raise ArgumentError.new("Expected the tag namea as a Symbol or String.")
+				else raise ArgumentError.new("Expected the tag name as a Symbol or String.")
 			end
 
 			if registered_elements[normalized_name]

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -213,7 +213,7 @@ module Phlex
 				else raise ArgumentError.new("Expected the tag namea as a Symbol or String.")
 			end
 
-			if name == "script"
+			if normalized_name == "script"
 				raise ArgumentError.new("You can’t use the `<script>` tag from the `tag` method. Use `unsafe_tag` instead, but be careful if using user input.")
 			end
 

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -210,7 +210,7 @@ module Phlex
 			normalized_name = case name
 				when Symbol then name.name.downcase
 				when String then name.downcase
-				else raise ArgumentError.new("Expected the tag namea as a Symbol or String.")
+				else raise ArgumentError.new("Expected the tag name as a Symbol or String.")
 			end
 
 			if normalized_name == "script"


### PR DESCRIPTION
Closes #707 

This provides a safer alternative to using `send` and `public_send` to dynamically call Phlex methods when using your own meta-programming.