### PR TITLE
Support inline tags

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -26,6 +26,7 @@ module Phlex
 	Escape = ERB::Escape
 	ATTRIBUTE_CACHE = FIFO.new
 	SUPPORTS_FIBER_STORAGE = RUBY_ENGINE == "ruby"
+	Null = Object.new.freeze
 end
 
 def 💪

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -61,8 +61,7 @@ module Phlex::Elements
 						buffer << "</#{tag}>"
 					elsif content
 						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << ">"
-						inline_block = content.is_a?(Proc) ? content : proc { content }
-						yield_content(&inline_block)
+						process_inline_content(content)
 						buffer << "</#{tag}>"
 					else # without content block
 						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << "></#{tag}>"
@@ -74,8 +73,7 @@ module Phlex::Elements
 						buffer << "</#{tag}>"
 					elsif content
 						buffer << "<#{tag}>"
-						inline_block = content.is_a?(Proc) ? content : proc { content }
-						yield_content(&inline_block)
+						process_inline_content(content)
 						buffer << "</#{tag}>"
 					else # without content block
 						buffer << "<#{tag}></#{tag}>"

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -32,7 +32,7 @@ module Phlex::Elements
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 
-			def #{method_name}(**attributes, &block)
+			def #{method_name}(content = nil, **attributes, &block)
 				context = @_context
 				buffer = context.buffer
 				fragment = context.fragments
@@ -59,6 +59,11 @@ module Phlex::Elements
 						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << ">"
 						yield_content(&block)
 						buffer << "</#{tag}>"
+					elsif content
+						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << ">"
+						inline_block = content.is_a?(Proc) ? content : proc { content }
+						yield_content(&inline_block)
+						buffer << "</#{tag}>"
 					else # without content block
 						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << "></#{tag}>"
 					end
@@ -66,6 +71,11 @@ module Phlex::Elements
 					if block # with content block
 						buffer << "<#{tag}>"
 						yield_content(&block)
+						buffer << "</#{tag}>"
+					elsif content
+						buffer << "<#{tag}>"
+						inline_block = content.is_a?(Proc) ? content : proc { content }
+						yield_content(&inline_block)
 						buffer << "</#{tag}>"
 					else # without content block
 						buffer << "<#{tag}></#{tag}>"

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -32,11 +32,19 @@ module Phlex::Elements
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
 
-			def #{method_name}(content = nil, **attributes, &block)
+			def #{method_name}(content = Phlex::Null, **attributes, &block)
 				context = @_context
 				buffer = context.buffer
 				fragment = context.fragments
 				target_found = false
+
+				if content != Phlex::Null && !content.is_a?(String)
+					raise ArgumentError.new("Only String allowed for inline tags content")
+				end
+
+				if block && content != Phlex::Null
+					raise ArgumentError.new("Using inline and block syntax at same time is forbidden")
+				end
 
 				if fragment
 					return if fragment.length == 0 # we found all our fragments already
@@ -59,11 +67,11 @@ module Phlex::Elements
 						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << ">"
 						yield_content(&block)
 						buffer << "</#{tag}>"
-					elsif content
+					elsif content != Phlex::Null # with inline content
 						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << ">"
-						process_inline_content(content)
+						plain(content)
 						buffer << "</#{tag}>"
-					else # without content block
+					else # without content
 						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << "></#{tag}>"
 					end
 				else # without attributes
@@ -71,11 +79,11 @@ module Phlex::Elements
 						buffer << "<#{tag}>"
 						yield_content(&block)
 						buffer << "</#{tag}>"
-					elsif content
+					elsif content != Phlex::Null # with inline content
 						buffer << "<#{tag}>"
-						process_inline_content(content)
+						plain(content)
 						buffer << "</#{tag}>"
-					else # without content block
+					else # without content
 						buffer << "<#{tag}></#{tag}>"
 					end
 				end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -353,6 +353,19 @@ module Phlex
 			nil
 		end
 
+		# Process inline content passed to a tag method
+		# [Block, Proc, String] are available. Raises ArgumentError in other cases
+		def process_inline_content(content)
+			case content
+			when Proc
+				yield_content(&content)
+			when String
+				plain(content)
+			else
+				raise ArgumentError.new("Only Block(Proc) and String variables allowed for inline tags content")
+			end
+		end
+
 		# Performs the same task as the public method #plain, but does not raise an error if an unformattable object is passed
 		# @api private
 		def __text__(content)

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -353,19 +353,6 @@ module Phlex
 			nil
 		end
 
-		# Process inline content passed to a tag method
-		# [Block, Proc, String] are available. Raises ArgumentError in other cases
-		def process_inline_content(content)
-			case content
-			when Proc
-				yield_content(&content)
-			when String
-				plain(content)
-			else
-				raise ArgumentError.new("Only Block(Proc) and String variables allowed for inline tags content")
-			end
-		end
-
 		# Performs the same task as the public method #plain, but does not raise an error if an unformattable object is passed
 		# @api private
 		def __text__(content)

--- a/test/phlex/view/renderable/render.rb
+++ b/test/phlex/view/renderable/render.rb
@@ -6,16 +6,6 @@ class Example < Phlex::HTML
 	end
 end
 
-class InlineExample < Phlex::HTML
-	def view_template
-		div class: "first" do
-			div class: "second" do
-				div "Hello", class: "third"
-			end
-		end
-	end
-end
-
 class InlineNestedExample < Phlex::HTML
 	# It's a specific case so it should be wrapped properly to keep execution sequence
 	def tag_method_wrapper(method_name, inline_content, **attributes)
@@ -137,12 +127,28 @@ describe Phlex::HTML do
 			with "regular nesting" do
 				view do
 					def view_template
-						render InlineExample
+						div class: "first" do
+							div class: "second" do
+								div "Hello", class: "third"
+							end
+						end
 					end
 				end
 
 				it "renders a new instance of that view" do
 					expect(output).to be == "<div class=\"first\"><div class=\"second\"><div class=\"third\">Hello</div></div></div>"
+				end
+			end
+
+			with "non block or string content" do
+				view do
+					def view_template
+						div :hello, class: "first"
+					end
+				end
+
+				it "raises argument error" do
+					expect { output }.to raise_exception(ArgumentError, message: be == "Only Block(Proc) and String variables allowed for inline tags content")
 				end
 			end
 		end


### PR DESCRIPTION
Based on [issue](https://github.com/phlex-ruby/phlex/issues/750)

Adding support of inline tag declaration
Examples:
```
h1 'Hello'
```
will render:
```
<h1>Hello</h1>
```

```
div do
  h1 'Hello', class: 'title'
end
```
will render:
```
<div><h1 class="title">Hello</h1></div>
```