### PR TITLE
Register SVG elements G | TEXT | CIRCLE

### DIFF
--- a/lib/phlex/html/standard_elements.rb
+++ b/lib/phlex/html/standard_elements.rb
@@ -724,4 +724,25 @@ module Phlex::HTML::StandardElements
 	# 	@yieldparam component [self]
 	# 	@see https://developer.mozilla.org/docs/Web/HTML/Element/wbr
 	register_element :wbr
+
+	# @!method g(**attributes, &content)
+	# 	Outputs a `<g>` tag.
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
+	register_element :g
+
+	# @!method text(**attributes, &content)
+	# 	Outputs a `<text>` tag.
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text
+	register_element :text
+
+	# @!method circle(**attributes, &content)
+	# 	Outputs a `<circle>` tag.
+	# 	@return [nil]
+	# 	@yieldparam component [self]
+	# 	@see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/circle
+	register_element :circle
 end


### PR DESCRIPTION
Recently I've created a custom Component on my APP and I needed to add a custom code, so here is my contribution

<img width="98" alt="image" src="https://github.com/user-attachments/assets/a74d923f-1f92-442b-9528-9c5510bc989f">

```
module Custom
  class Meter < ApplicationComponent
    extend Phlex::Elements

    register_element :g
    register_element :text
    register_element :circle

    def initialize(size:, text:, percentage:)
      super()

      @size = size
      @text = text
      @percentage = percentage
    end

    def view_template
      r = @size / 2
      cx_cy = r * 1.5
      svg_size = @size * 1.5
      stroke_dasharray = 2 * Math::PI * r
      stroke_percentage = ((100 - @percentage) * stroke_dasharray) / 100

      svg(width: svg_size, height: svg_size, style: "flex: none; margin: -#{svg_size / 8}") do
        g(transform: "rotate(-90 #{cx_cy} #{cx_cy})") do
          circle(
            r:,
            cx: cx_cy,
            cy: cx_cy,
            fill: "transparent",
            "stroke-width": r * 0.2,
            "stroke-dashoffset": "0",
            stroke: "rgb(226 232 240)",
            "stroke-dasharray": stroke_dasharray
          )

          circle(
            r:,
            cx: cx_cy,
            cy: cx_cy,
            fill: "transparent",
            "stroke-width": r * 0.2,
            stroke: "rgb(34 197 94)",
            "stroke-dasharray": stroke_dasharray,
            "stroke-dashoffset": stroke_percentage
          )
        end

        if @text.present?
          text(
            x: "50%",
            y: "50%",
            "font-size": @size / 3,
            "text-anchor": "middle",
            "dominant-baseline": "central"
          ) { @text }
        end
      end
    end
  end
end
```