### PR TITLE
Simplify FIFO cache

### DIFF
--- a/lib/phlex/fifo.rb
+++ b/lib/phlex/fifo.rb
@@ -18,8 +18,7 @@ class Phlex::FIFO
 	end
 
 	def [](key)
-		k, v = @hash[key.hash]
-		v if k == key
+		@hash[key]
 	end
 
 	def []=(key, value)
@@ -27,18 +26,16 @@ class Phlex::FIFO
 			return value
 		end
 
-		hash = key.hash
-
 		@mutex.synchronize do
 			# Check the key definitely doesn't exist now we have the lock
-			return if @hash[hash]
+			return if @hash[key]
 
-			@hash[hash] = [key, value]
+			@hash[key] = value
 			@bytesize += value.bytesize
 
 			while @bytesize > @max_bytesize
 				k, v = @hash.shift
-				@bytesize -= v[1].bytesize
+				@bytesize -= v.bytesize
 			end
 		end
 	end


### PR DESCRIPTION
Use the attributes hash as the cache key directly.

**Before**
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) +YJIT [arm64-darwin23]
Warming up --------------------------------------
                Page   335.000 i/100ms
Calculating -------------------------------------
                Page      3.369k (± 0.6%) i/s -     17.085k in   5.071279s
```

**After**
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) +YJIT [arm64-darwin23]
Warming up --------------------------------------
                Page   275.000 i/100ms
Calculating -------------------------------------
                Page      2.760k (± 0.7%) i/s -     14.025k in   5.082058s
```