### PR TITLE
Replace `_` with `-` in Symbol attribute values

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -442,7 +442,7 @@ class Phlex::SGML
 			when String
 				buffer << " " << name << '="' << v.gsub('"', "&quot;") << '"'
 			when Symbol
-				buffer << " " << name << '="' << v.name.gsub('"', "&quot;") << '"'
+				buffer << " " << name << '="' << v.name.tr("_", "-").gsub('"', "&quot;") << '"'
 			when Integer, Float
 				buffer << " " << name << '="' << v.to_s << '"'
 			when Hash
@@ -503,7 +503,7 @@ class Phlex::SGML
 			when String
 				buffer << " " << base_name << name << '="' << v.gsub('"', "&quot;") << '"'
 			when Symbol
-				buffer << " " << base_name << name << '="' << v.name.gsub('"', "&quot;") << '"'
+				buffer << " " << name << '="' << v.name.tr("_", "-").gsub('"', "&quot;") << '"'
 			when Integer, Float
 				buffer << " " << base_name << name << '="' << v.to_s << '"'
 			when Hash
@@ -545,9 +545,9 @@ class Phlex::SGML
 				end
 			when Symbol
 				if i > 0
-					buffer << " " << token.name
+					buffer << " " << token.name.tr("_", "-")
 				else
-					buffer << token.name
+					buffer << token.name.tr("_", "-")
 				end
 			when nil
 				# Do nothing


### PR DESCRIPTION
This provides better consistency with Symbol keys and makes it easier to work with standard multi-word HTML attribute values, such as `contenteditable: :plaintext_only`.