### PR TITLE
Allow elements to output safe return values

### DIFF
--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -69,6 +69,8 @@ module Phlex::Elements
 								buffer << Phlex::Escape.html_escape(content.name)
 							when nil
 								nil
+							when Phlex::SGML::SafeObject
+								buffer << content.to_s
 							else
 								if (formatted_object = format_object(content))
 									buffer << Phlex::Escape.html_escape(formatted_object)
@@ -94,6 +96,8 @@ module Phlex::Elements
 								buffer << Phlex::Escape.html_escape(content.name)
 							when nil
 								nil
+							when Phlex::SGML::SafeObject
+								buffer << content.to_s
 							else
 								if (formatted_object = format_object(content))
 									buffer << Phlex::Escape.html_escape(formatted_object)

--- a/quickdraw/sgml/safe_value.test.rb
+++ b/quickdraw/sgml/safe_value.test.rb
@@ -12,3 +12,13 @@ end
 test "safe value" do
 	expect(Example.call) == %(<a onclick="window.history.back()" href="javascript:window.history.back()"></a>)
 end
+
+class ExampleScript < Phlex::HTML
+  def view_template
+    script { safe(%(console.log("Hello World");)) }
+  end
+end
+
+test "element content blocks that return safe values" do
+  expect(ExampleScript.call) == %(<script>console.log("Hello World");</script>)
+end


### PR DESCRIPTION
### Before

```ruby
script { safe(%(console.log("Hi 👋"))) } # => <script></script>
```

### After
```ruby
script { safe(%(console.log("Hi 👋"))) } # => <script>console.log("Hi 👋")</script>
```
