### PR TITLE
Fix `mix` to accept old or new nil values

### DIFF
--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -26,8 +26,10 @@ module Phlex::Helpers
 					[old] + new.to_a
 				in [String, String]
 					"#{old} #{new}"
+				in [_, nil]
+					old
 				else
-					new.nil? ? old : new
+					new
 				end
 			end
 

--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -26,10 +26,8 @@ module Phlex::Helpers
 					[old] + new.to_a
 				in [String, String]
 					"#{old} #{new}"
-				in [String, nil]
-					old
 				else
-					new
+					new.nil? ? old : new
 				end
 			end
 

--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -26,6 +26,8 @@ module Phlex::Helpers
 					[old] + new.to_a
 				in [String, String]
 					"#{old} #{new}"
+				in [String, nil]
+					old
 				else
 					new
 				end

--- a/quickdraw/helpers/mix.test.rb
+++ b/quickdraw/helpers/mix.test.rb
@@ -7,6 +7,11 @@ test "nil + string" do
 	expect(output) == { class: "a" }
 end
 
+test "string + nil" do
+	output = mix({ class: "a" }, { class: nil })
+	expect(output) == { class: "a" }
+end
+
 test "array + array" do
 	output = mix({ class: ["foo"] }, { class: ["bar"] })
 	expect(output) == { class: ["foo", "bar"] }

--- a/quickdraw/helpers/mix.test.rb
+++ b/quickdraw/helpers/mix.test.rb
@@ -12,6 +12,11 @@ test "string + nil" do
 	expect(output) == { class: "a" }
 end
 
+test "array + nil" do
+	output = mix({ class: ["foo", "bar"] }, { class: nil })
+	expect(output) == { class: ["foo", "bar"] }
+end
+
 test "array + array" do
 	output = mix({ class: ["foo"] }, { class: ["bar"] })
 	expect(output) == { class: ["foo", "bar"] }


### PR DESCRIPTION
Fixes https://github.com/phlex-ruby/phlex/issues/779, but ~I don't think it's all the way there because it only handles the `[String, nil]` combo~. I don't know the reasons the code changed for `mix` so much in https://github.com/phlex-ruby/phlex/commit/0f8d8cbc6b919a4749674a6f68d7b426f5d97ecc#diff-1379affdd94a5363d3331840af91bc6171dac9338b2f6bd886a0636ac6258a38, so this is more a starting point.

Update: in the second commit I made it work for the other types, but I'm sure there are other approaches to consider.