### PR TITLE
Remove deferred render

### DIFF
--- a/lib/phlex/html/standard_elements.rb
+++ b/lib/phlex/html/standard_elements.rb
@@ -5,44 +5,83 @@ module Phlex::HTML::StandardElements
 	extend Phlex::SGML::Elements
 
 	# Outputs an `<a>` tag.
+	# The `<a>` element creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/a
-	def a(id: nil, class: nil, href: nil, target: nil, **attributes, &content) = nil
-	register_element :a, tag: "a"
+	register_element def a(
+		class: nil,
+		href: nil,
+		id: nil,
+		rel: nil,
+		target: nil,
+		title: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<abbr>` tag.
+	# The `<abbr>` element represents an abbreviation or acronym.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/abbr
-	def abbr(id: nil, class: nil, **attributes, &content) = nil
-	register_element :abbr
+	register_element def abbr(
+		class: nil,
+		id: nil,
+		title: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<address>` tag.
+	# The `<address>` element indicates contact information for a person or organization.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/address
-	def address(id: nil, class: nil, **attributes, &content) = nil
-	register_element :address
+	register_element def address(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<article>` tag.
+	# The `<article>` element represents a self-contained composition in a document, page, application, or site.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/article
-	def article(id: nil, class: nil, **attributes, &content) = nil
-	register_element :article
+	register_element def article(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<aside>` tag.
+	# The `<aside>` element represents a section of a page that consists of content that is tangentially related to the content around the aside element.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/aside
-	def aside(id: nil, class: nil, **attributes, &content) = nil
-	register_element :aside
+	register_element def aside(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<audio>` tag.
 	# See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
-	def audio(id: nil, class: nil, **attributes, &content) = nil
+	def audio(
+		autoplay: nil,
+		class: nil,
+		controls: nil,
+		id: nil,
+		loop: nil,
+		src: nil,
+		**attributes,
+		&content
+	) = nil
 	register_element :audio
 
 	# Outputs a `<b>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/b
-	def b(id: nil, class: nil, **attributes, &content) = nil
+	def b(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 	register_element :b
-
-	# Outputs a `<base>` tag.
-	# See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
-	def base(id: nil, class: nil, **attributes, &content) = nil
-	register_element :base
 
 	# Outputs a `<bdi>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/bdi
@@ -51,12 +90,12 @@ module Phlex::HTML::StandardElements
 
 	# Outputs a `<bdo>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/bdo
-	def bdo(id: nil, class: nil, **attributes, &content) = nil
+	def bdo(id: nil, class: nil, dir: nil, **attributes, &content) = nil
 	register_element :bdo
 
 	# Outputs a `<blockquote>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/blockquote
-	def blockquote(id: nil, class: nil, **attributes, &content) = nil
+	def blockquote(id: nil, class: nil, cite: nil, **attributes, &content) = nil
 	register_element :blockquote
 
 	# Outputs a `<body>` tag.
@@ -65,457 +104,919 @@ module Phlex::HTML::StandardElements
 	register_element :body
 
 	# Outputs a `<button>` tag.
+	# The `<button>` element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology to perform an action, such as submitting a form or opening a dialog.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/button
-	def button(id: nil, class: nil, **attributes, &content) = nil
-	register_element :button
+	register_element def button(
+		autofocus: nil,
+		class: nil,
+		disabled: nil,
+		form: nil,
+		formaction: nil,
+		formmethod: nil,
+		formtarget: nil,
+		formvalidate: nil,
+		id: nil,
+		name: nil,
+		popovertarget: nil,
+		popovertargetaction: nil,
+		type: nil,
+		value: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<canvas>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/canvas
-	def canvas(id: nil, class: nil, **attributes, &content) = nil
-	register_element :canvas
+	register_element def canvas(
+		class: nil,
+		height: nil,
+		id: nil,
+		width: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<caption>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/caption
-	def caption(id: nil, class: nil, **attributes, &content) = nil
-	register_element :caption
+	register_element def caption(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<cite>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/cite
-	def cite(id: nil, class: nil, **attributes, &content) = nil
-	register_element :cite
+	register_element def cite(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<code>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/code
-	def code(id: nil, class: nil, **attributes, &content) = nil
-	register_element :code
+	register_element def code(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<colgroup>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/colgroup
-	def colgroup(id: nil, class: nil, **attributes, &content) = nil
-	register_element :colgroup
+	register_element def colgroup(
+		class: nil,
+		id: nil,
+		span: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<data>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/data
-	def data(id: nil, class: nil, **attributes, &content) = nil
-	register_element :data
+	register_element def data(
+		class: nil,
+		id: nil,
+		value: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<datalist>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/datalist
-	def datalist(id: nil, class: nil, **attributes, &content) = nil
-	register_element :datalist
+	register_element def datalist(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<dd>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/dd
-	def dd(id: nil, class: nil, **attributes, &content) = nil
-	register_element :dd
+	register_element def dd(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<del>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/del
-	def del(id: nil, class: nil, **attributes, &content) = nil
-	register_element :del
+	register_element def del(
+		cite: nil,
+		class: nil,
+		datetime: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<details>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/details
-	def details(id: nil, class: nil, **attributes, &content) = nil
-	register_element :details
+	register_element def details(
+		class: nil,
+		id: nil,
+		open: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<dfn>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/dfn
-	def dfn(id: nil, class: nil, **attributes, &content) = nil
-	register_element :dfn
+	register_element def dfn(
+		class: nil,
+		id: nil,
+		title: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<dialog>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/dialog
-	def dialog(id: nil, class: nil, **attributes, &content) = nil
-	register_element :dialog
+	register_element def dialog(
+		class: nil,
+		id: nil,
+		open: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<div>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/div
-	def div(id: nil, class: nil, **attributes, &content) = nil
-	register_element :div
+	register_element def div(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<dl>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/dl
-	def dl(id: nil, class: nil, **attributes, &content) = nil
-	register_element :dl
+	register_element def dl(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<dt>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/dt
-	def dt(id: nil, class: nil, **attributes, &content) = nil
-	register_element :dt
+	register_element def dt(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<em>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/em
-	def em(id: nil, class: nil, **attributes, &content) = nil
-	register_element :em
+	register_element def em(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<fieldset>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/fieldset
-	def fieldset(id: nil, class: nil, **attributes, &content) = nil
-	register_element :fieldset
+	register_element def fieldset(
+		class: nil,
+		disabled: nil,
+		form: nil,
+		id: nil,
+		name: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<figcaption>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/figcaption
-	def figcaption(id: nil, class: nil, **attributes, &content) = nil
-	register_element :figcaption
+	register_element def figcaption(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<figure>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/figure
-	def figure(id: nil, class: nil, **attributes, &content) = nil
-	register_element :figure
+	register_element def figure(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<footer>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/footer
-	def footer(id: nil, class: nil, **attributes, &content) = nil
-	register_element :footer
+	register_element def footer(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<form>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/form
-	def form(id: nil, class: nil, **attributes, &content) = nil
-	register_element :form
+	register_element def form(
+		action: nil,
+		class: nil,
+		enctype: nil,
+		id: nil,
+		method: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<h1>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/h1
-	def h1(id: nil, class: nil, **attributes, &content) = nil
-	register_element :h1
+	register_element def h1(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<h2>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/h2
-	def h2(id: nil, class: nil, **attributes, &content) = nil
-	register_element :h2
+	register_element def h2(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<h3>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/h3
-	def h3(id: nil, class: nil, **attributes, &content) = nil
-	register_element :h3
+	register_element def h3(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<h4>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/h4
-	def h4(id: nil, class: nil, **attributes, &content) = nil
-	register_element :h4
+	register_element def h4(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<h5>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/h5
-	def h5(id: nil, class: nil, **attributes, &content) = nil
-	register_element :h5
+	register_element def h5(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<h6>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/h6
-	def h6(id: nil, class: nil, **attributes, &content) = nil
-	register_element :h6
+	register_element def h6(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<head>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/head
-	def head(id: nil, class: nil, **attributes, &content) = nil
-	register_element :head
+	register_element def head(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<header>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/header
-	def header(id: nil, class: nil, **attributes, &content) = nil
-	register_element :header
+	register_element def header(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<hgroup>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/hgroup
-	def hgroup(id: nil, class: nil, **attributes, &content) = nil
-	register_element :hgroup
+	register_element def hgroup(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<html>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/html
-	def html(id: nil, class: nil, **attributes, &content) = nil
-	register_element :html
+	register_element def html(
+		class: nil,
+		id: nil,
+		lang: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<i>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/i
-	def i(id: nil, class: nil, **attributes, &content) = nil
-	register_element :i
+	register_element def i(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<iframe>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/iframe
-	def iframe(id: nil, class: nil, name: nil, src: nil, srcdoc: nil, **attributes, &content) = nil
-	register_element :iframe
+	register_element def iframe(
+		class: nil,
+		height: nil,
+		id: nil,
+		name: nil,
+		src: nil,
+		srcdoc: nil,
+		width: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<ins>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/ins
-	def ins(id: nil, class: nil, **attributes, &content) = nil
-	register_element :ins
+	register_element def ins(
+		cite: nil,
+		class: nil,
+		datetime: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<kbd>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/kbd
-	def kbd(id: nil, class: nil, **attributes, &content) = nil
-	register_element :kbd
+	register_element def kbd(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<label>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/label
-	def label(id: nil, class: nil, for: nil, **attributes, &content) = nil
-	register_element :label
+	register_element def label(
+		class: nil,
+		for: nil,
+		form: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<legend>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/legend
-	def legend(id: nil, class: nil, **attributes, &content) = nil
-	register_element :legend
+	register_element def legend(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<li>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/li
-	def li(id: nil, class: nil, **attributes, &content) = nil
-	register_element :li
+	register_element def li(
+		class: nil,
+		id: nil,
+		value: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<main>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/main
-	def main(id: nil, class: nil, **attributes, &content) = nil
-	register_element :main
+	register_element def main(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<map>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/map
-	def map(id: nil, class: nil, **attributes, &content) = nil
-	register_element :map
+	register_element def map(
+		class: nil,
+		id: nil,
+		name: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<mark>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/mark
-	def mark(id: nil, class: nil, **attributes, &content) = nil
-	register_element :mark
+	register_element def mark(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<menu>` tag.
 	# See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
-	def menu(id: nil, class: nil, **attributes, &content) = nil
-	register_element :menu
+	register_element def menu(
+		class: nil,
+		id: nil,
+		type: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<meter>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/meter
-	def meter(id: nil, class: nil, **attributes, &content) = nil
-	register_element :meter
+	register_element def meter(
+		class: nil,
+		high: nil,
+		id: nil,
+		low: nil,
+		max: nil,
+		min: nil,
+		optimum: nil,
+		value: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<nav>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/nav
-	def nav(id: nil, class: nil, **attributes, &content) = nil
-	register_element :nav
+	register_element def nav(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<noscript>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/noscript
-	def noscript(id: nil, class: nil, **attributes, &content) = nil
-	register_element :noscript
+	register_element def noscript(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<object>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/object
-	def object(id: nil, class: nil, **attributes, &content) = nil
-	register_element :object
+	register_element def object(
+		class: nil,
+		data: nil,
+		height: nil,
+		id: nil,
+		type: nil,
+		width: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<ol>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/ol
-	def ol(id: nil, class: nil, **attributes, &content) = nil
-	register_element :ol
+	register_element def ol(
+		class: nil,
+		id: nil,
+		reversed: nil,
+		start: nil,
+		type: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<optgroup>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/optgroup
-	def optgroup(id: nil, class: nil, **attributes, &content) = nil
-	register_element :optgroup
+	register_element def optgroup(
+		class: nil,
+		disabled: nil,
+		id: nil,
+		label: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<option>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/option
-	def option(id: nil, class: nil, **attributes, &content) = nil
-	register_element :option
+	register_element def option(
+		class: nil,
+		disabled: nil,
+		id: nil,
+		selected: nil,
+		value: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<output>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/output
-	def output(id: nil, class: nil, **attributes, &content) = nil
-	register_element :output
+	register_element def output(
+		class: nil,
+		for: nil,
+		form: nil,
+		id: nil,
+		name: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<p>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/p
-	def p(id: nil, class: nil, **attributes, &content) = nil
-	register_element :p
+	register_element def p(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<picture>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/picture
-	def picture(id: nil, class: nil, **attributes, &content) = nil
-	register_element :picture
+	register_element def picture(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<portal>` tag. (Experimental)
 	# See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/portal
-	def portal(id: nil, class: nil, **attributes, &content) = nil
-	register_element :portal
+	register_element def portal(
+		class: nil,
+		id: nil,
+		src: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<pre>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/pre
-	def pre(id: nil, class: nil, **attributes, &content) = nil
-	register_element :pre
+	register_element def pre(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<progress>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/progress
-	def progress(id: nil, class: nil, **attributes, &content) = nil
-	register_element :progress
+	register_element def progress(
+		class: nil,
+		id: nil,
+		max: nil,
+		value: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<q>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/q
-	def q(id: nil, class: nil, **attributes, &content) = nil
-	register_element :q
+	register_element def q(
+		cite: nil,
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<rp>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/rp
-	def rp(id: nil, class: nil, **attributes, &content) = nil
-	register_element :rp
+	register_element def rp(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<rt>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/rt
-	def rt(id: nil, class: nil, **attributes, &content) = nil
-	register_element :rt
+	register_element def rt(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<ruby>` tag. (The best tag ever!)
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/ruby
-	def ruby(id: nil, class: nil, **attributes, &content) = nil
-	register_element :ruby
+	register_element def ruby(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<s>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/s
-	def s(id: nil, class: nil, **attributes, &content) = nil
-	register_element :s
+	register_element def s(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<samp>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/samp
-	def samp(id: nil, class: nil, **attributes, &content) = nil
-	register_element :samp
+	register_element def samp(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<script>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/script
-	def script(id: nil, class: nil, **attributes, &content) = nil
-	register_element :script
+	register_element def script(
+		async: nil,
+		class: nil,
+		defer: nil,
+		id: nil,
+		src: nil,
+		type: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<search>` tag.
 	# See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
-	def search(id: nil, class: nil, **attributes, &content) = nil
-	register_element :search
+	register_element def search(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<section>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/section
-	def section(id: nil, class: nil, **attributes, &content) = nil
-	register_element :section
+	register_element def section(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<select>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/select
-	def select(id: nil, class: nil, **attributes, &content) = nil
-	register_element :select
+	register_element def select(
+		class: nil,
+		id: nil,
+		multiple: nil,
+		name: nil,
+		size: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<slot>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/slot
-	def slot(id: nil, class: nil, **attributes, &content) = nil
-	register_element :slot
+	register_element def slot(
+		class: nil,
+		id: nil,
+		name: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<small>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/small
-	def small(id: nil, class: nil, **attributes, &content) = nil
-	register_element :small
+	register_element def small(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<span>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/span
-	def span(id: nil, class: nil, **attributes, &content) = nil
-	register_element :span
+	register_element def span(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<strong>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/strong
-	def strong(id: nil, class: nil, **attributes, &content) = nil
-	register_element :strong
+	register_element def strong(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<style>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/style
-	def style(id: nil, class: nil, **attributes, &content) = nil
-	register_element :style
+	register_element def style(
+		class: nil,
+		id: nil,
+		media: nil,
+		type: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<sub>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/sub
-	def sub(id: nil, class: nil, **attributes, &content) = nil
-	register_element :sub
+	register_element def sub(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<summary>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/summary
-	def summary(id: nil, class: nil, **attributes, &content) = nil
-	register_element :summary
+	register_element def summary(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<sup>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/sup
-	def sup(id: nil, class: nil, **attributes, &content) = nil
-	register_element :sup
+	register_element def sup(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs an `<svg>` tag.
 	# See https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
-	def svg(id: nil, class: nil, **attributes, &content) = nil
-	register_element :svg
+	register_element def svg(
+		class: nil,
+		height: nil,
+		id: nil,
+		viewBox: nil,
+		width: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<table>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/table
-	def table(id: nil, class: nil, **attributes, &content) = nil
-	register_element :table
+	register_element def table(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<tbody>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/tbody
-	def tbody(id: nil, class: nil, **attributes, &content) = nil
-	register_element :tbody
+	register_element def tbody(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<td>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/td
-	def td(id: nil, class: nil, **attributes, &content) = nil
-	register_element :td
+	register_element def td(
+		class: nil,
+		colspan: nil,
+		headers: nil,
+		id: nil,
+		rowspan: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<template>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/template
-	def template_tag(id: nil, class: nil, **attributes, &content) = nil
-	register_element :template
+	register_element def template(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<textarea>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/textarea
-	def textarea(id: nil, class: nil, **attributes, &content) = nil
-	register_element :textarea
+	register_element def textarea(
+		class: nil,
+		cols: nil,
+		disabled: nil,
+		id: nil,
+		name: nil,
+		readonly: nil,
+		rows: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<tfoot>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/tfoot
-	def tfoot(id: nil, class: nil, **attributes, &content) = nil
-	register_element :tfoot
+	register_element def tfoot(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<th>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/th
-	def th(id: nil, class: nil, **attributes, &content) = nil
-	register_element :th
+	register_element def th(
+		class: nil,
+		colspan: nil,
+		headers: nil,
+		id: nil,
+		rowspan: nil,
+		scope: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<thead>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/thead
-	def thead(id: nil, class: nil, **attributes, &content) = nil
-	register_element :thead
+	register_element def thead(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<time>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/time
-	def time(id: nil, class: nil, **attributes, &content) = nil
-	register_element :time
+	register_element def time(
+		class: nil,
+		datetime: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<title>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/title
-	def title(id: nil, class: nil, **attributes, &content) = nil
-	register_element :title
+	register_element def title(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<tr>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/tr
-	def tr(id: nil, class: nil, **attributes, &content) = nil
-	register_element :tr
+	register_element def tr(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<u>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/u
-	def u(id: nil, class: nil, **attributes, &content) = nil
-	register_element :u
+	register_element def u(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<ul>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/ul
-	def ul(id: nil, class: nil, **attributes, &content) = nil
-	register_element :ul
+	register_element def ul(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<var>` tag.
 	# See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
-	def var(id: nil, class: nil, **attributes, &content) = nil
-	register_element :var
+	register_element def var(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<video>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/video
-	def video(id: nil, class: nil, **attributes, &content) = nil
-	register_element :video
+	register_element def video(
+		autoplay: nil,
+		class: nil,
+		controls: nil,
+		height: nil,
+		id: nil,
+		loop: nil,
+		src: nil,
+		width: nil,
+		**attributes,
+		&content
+	) = nil
 
 	# Outputs a `<wbr>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/wbr
-	def wbr(id: nil, class: nil, **attributes, &content) = nil
-	register_element :wbr
+	register_element def wbr(
+		class: nil,
+		id: nil,
+		**attributes,
+		&content
+	) = nil
 end

--- a/lib/phlex/html/void_elements.rb
+++ b/lib/phlex/html/void_elements.rb
@@ -6,56 +6,106 @@ module Phlex::HTML::VoidElements
 
 	# Outputs an `<area>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/area
-	def area(id: nil, class: nil, **attributes) = nil
-	__register_void_element__ :area
+	__register_void_element__ def area(
+		class: nil,
+		id: nil,
+		**attributes
+	) = nil
+
+	# Outputs a `<base>` tag.
+	# See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+	def base(
+		class: nil,
+		href: nil,
+		id: nil,
+		target: nil,
+		**attributes
+	) = nil
+	register_element :base
 
 	# Outputs a `<br>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/br
-	def br(id: nil, class: nil, **attributes) = nil
-	__register_void_element__ :br
+	__register_void_element__ def br(
+		class: nil,
+		id: nil,
+		**attributes
+	) = nil
 
 	# Outputs a `<col>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/col
-	def col(id: nil, class: nil, **attributes) = nil
-	__register_void_element__ :col
+	__register_void_element__ def col(
+		class: nil,
+		id: nil,
+		**attributes
+	) = nil
 
 	# Outputs an `<embed>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/embed
-	def embed(id: nil, class: nil, **attributes) = nil
-	__register_void_element__ :embed
+	__register_void_element__ def embed(
+		class: nil,
+		id: nil,
+		**attributes
+	) = nil
 
 	# Outputs an `<hr>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/hr
-	def hr(id: nil, class: nil, **attributes) = nil
-	__register_void_element__ :hr
+	__register_void_element__ def hr(
+		class: nil,
+		id: nil,
+		**attributes
+	) = nil
 
 	# Outputs an `<img>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/img
-	def img(id: nil, class: nil, src: nil, alt: nil, **attributes) = nil
-	__register_void_element__ :img
+	__register_void_element__ def img(
+		alt: nil,
+		class: nil,
+		id: nil,
+		src: nil,
+		**attributes
+	) = nil
 
 	# Outputs an `<input>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/input
-	def input(id: nil, class: nil, type: nil, name: nil, **attributes) = nil
-	__register_void_element__ :input
+	__register_void_element__ def input(
+		class: nil,
+		id: nil,
+		name: nil,
+		type: nil,
+		**attributes
+	) = nil
 
 	# Outputs a `<link>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/link
-	def link(id: nil, class: nil, **attributes) = nil
-	__register_void_element__ :link
+	__register_void_element__ def link(
+		class: nil,
+		id: nil,
+		**attributes
+	) = nil
 
 	# Outputs a `<meta>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/meta
-	def meta(id: nil, class: nil, name: nil, charset: nil, **attributes) = nil
-	__register_void_element__ :meta
+	__register_void_element__ def meta(
+		charset: nil,
+		class: nil,
+		id: nil,
+		name: nil,
+		**attributes
+	) = nil
 
 	# Outputs a `<source>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/source
-	def source(id: nil, class: nil, **attributes) = nil
-	__register_void_element__ :source
+	__register_void_element__ def source(
+		class: nil,
+		id: nil,
+		**attributes
+	) = nil
 
 	# Outputs a `<track>` tag.
 	# See https://developer.mozilla.org/docs/Web/HTML/Element/track
-	def track(id: nil, class: nil, **attributes) = nil
-	__register_void_element__ :track
+	__register_void_element__ def track(
+		class: nil,
+		id: nil,
+		**attributes
+	) = nil
 end

--- a/quickdraw/sgml/capture.test.rb
+++ b/quickdraw/sgml/capture.test.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class ExampleCaptureWithArguments < Phlex::HTML
-	def view_template(&block)
-		h1 { capture("a", "b", "c", &block) }
+	def yielder = yield("a", "b", "c")
+
+	def view_template(...)
+		h1(...)
 	end
 end
 


### PR DESCRIPTION
This change removes the deferred render pattern as something you can opt into and instead makes it the default behaviour, with one small difference. You can `yield` any content that was captured from the component. It is no longer vanished.