### PR TITLE
safe values should be raw

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -305,6 +305,8 @@ class Phlex::SGML
 		return true if context.fragments && !context.in_target_fragment
 
 		case content
+		when Phlex::SGML::SafeObject
+		  context.buffer << content.to_s
 		when String
 			context.buffer << Phlex::Escape.html_escape(content)
 		when Symbol

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -120,7 +120,7 @@ class Phlex::SGML
 	end
 
 	def plain(content)
-		unless  __text__(content)
+		unless __text__(content)
 			raise Phlex::ArgumentError.new("You've passed an object to plain that is not handled by format_object. See https://rubydoc.info/gems/phlex/Phlex/SGML#format_object-instance_method for more information")
 		end
 
@@ -271,7 +271,7 @@ class Phlex::SGML
 
 		original_length = buffer.bytesize
 		content = yield(self)
-	  __implicit_output__(content) if original_length == buffer.bytesize
+		__implicit_output__(content) if original_length == buffer.bytesize
 
 		nil
 	end
@@ -283,7 +283,7 @@ class Phlex::SGML
 
 		original_length = buffer.bytesize
 		content = yield
-	  __implicit_output__(content) if original_length == buffer.bytesize
+		__implicit_output__(content) if original_length == buffer.bytesize
 
 		nil
 	end
@@ -295,18 +295,18 @@ class Phlex::SGML
 
 		original_length = buffer.bytesize
 		content = yield(*)
-	  __implicit_output__(content) if original_length == buffer.bytesize
+		__implicit_output__(content) if original_length == buffer.bytesize
 
 		nil
 	end
 
-	def  __implicit_output__(content)
+	def __implicit_output__(content)
 		context = @_context
 		return true if context.fragments && !context.in_target_fragment
 
 		case content
 		when Phlex::SGML::SafeObject
-		  context.buffer << content.to_s
+			context.buffer << content.to_s
 		when String
 			context.buffer << Phlex::Escape.html_escape(content)
 		when Symbol
@@ -325,9 +325,9 @@ class Phlex::SGML
 	end
 
 	# same as __implicit_output__ but escapes even `safe` objects
-	def  __text__(content)
-  	context = @_context
-  	return true if context.fragments && !context.in_target_fragment
+	def __text__(content)
+		context = @_context
+		return true if context.fragments && !context.in_target_fragment
 
 		case content
 		when String

--- a/lib/phlex/sgml/elements.rb
+++ b/lib/phlex/sgml/elements.rb
@@ -40,14 +40,14 @@ module Phlex::SGML::Elements
 						content = yield(self)
 						if original_length == buffer.bytesize
 							case content
+							when ::Phlex::SGML::SafeObject
+								buffer << content.to_s
 							when String
 								buffer << ::Phlex::Escape.html_escape(content)
 							when Symbol
 								buffer << ::Phlex::Escape.html_escape(content.name)
 							when nil
 								nil
-							when ::Phlex::SGML::SafeObject
-								buffer << content.to_s
 							else
 								if (formatted_object = format_object(content))
 									buffer << ::Phlex::Escape.html_escape(formatted_object)
@@ -67,14 +67,14 @@ module Phlex::SGML::Elements
 						content = yield(self)
 						if original_length == buffer.bytesize
 							case content
+							when ::Phlex::SGML::SafeObject
+								buffer << content.to_s
 							when String
 								buffer << ::Phlex::Escape.html_escape(content)
 							when Symbol
 								buffer << ::Phlex::Escape.html_escape(content.name)
 							when nil
 								nil
-							when ::Phlex::SGML::SafeObject
-								buffer << content.to_s
 							else
 								if (formatted_object = format_object(content))
 									buffer << ::Phlex::Escape.html_escape(formatted_object)


### PR DESCRIPTION
@joeldrapper @willcosgrove 
so I made `html_safe` and `safe` consistent in this pr and also created `__implicit_output__` and made `plain` use old `__text__` instead so we can render `html_safe` as `raw` by default, unless it's `plain`. Does that look good?