### PR TITLE
Remove underscored element aliases

### DIFF
--- a/lib/phlex/sgml/elements.rb
+++ b/lib/phlex/sgml/elements.rb
@@ -94,8 +94,6 @@ module Phlex::SGML::Elements
 
 				nil
 			end
-
-			alias_method :_#{method_name}, :#{method_name}
 		RUBY
 
 		__registered_elements__[method_name] = tag

--- a/quickdraw/html/standard_elements.test.rb
+++ b/quickdraw/html/standard_elements.test.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
 Phlex::HTML::StandardElements.__registered_elements__.each do |method_name, tag|
-	test "<#{tag}> called with an underscore prefix while overridden" do
-		example = Class.new(Phlex::HTML) do
-			define_method :view_template do
-				__send__("_#{method_name}")
-			end
-
-			define_method method_name do
-				super(class: "overridden")
-			end
-		end
-
-		expect(example.call) == %(<#{tag}></#{tag}>)
-	end
-
 	test "<#{tag}> with block content and attributes" do
 		example = Class.new(Phlex::HTML) do
 			define_method :view_template do

--- a/quickdraw/html/void_elements.test.rb
+++ b/quickdraw/html/void_elements.test.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
 Phlex::HTML::VoidElements.__registered_elements__.each do |method_name, tag|
-	test "<#{tag}> called with an underscore prefix while overridden" do
-		example = Class.new(Phlex::HTML) do
-			define_method :view_template do
-				__send__("_#{method_name}")
-			end
-
-			define_method tag do
-				super(class: "overridden")
-			end
-		end
-
-		expect(example.call) == %(<#{tag}>)
-	end
-
 	test "<#{tag}> with attributes" do
 		example = Class.new(Phlex::HTML) do
 			define_method :view_template do

--- a/quickdraw/svg/standard_elements.test.rb
+++ b/quickdraw/svg/standard_elements.test.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
 Phlex::SVG::StandardElements.__registered_elements__.each do |method_name, tag|
-	test "<#{tag}> called with an underscore prefix while overridden" do
-		example = Class.new(Phlex::SVG) do
-			define_method :view_template do
-				__send__("_#{method_name}")
-			end
-
-			define_method method_name do
-				super(class: "overridden")
-			end
-		end
-
-		expect(example.call) == %(<#{tag}></#{tag}>)
-	end
-
 	test "<#{tag}> with block text content and attributes" do
 		example = Class.new(Phlex::SVG) do
 			define_method :view_template do


### PR DESCRIPTION
You’ll be able to use `tag` instead.