### PR TITLE
Remove deferred render entirely

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -9,7 +9,6 @@ module Phlex
 	autoload :CSV, "phlex/csv"
 	autoload :Callable, "phlex/callable"
 	autoload :Context, "phlex/context"
-	autoload :DeferredRender, "phlex/deferred_render"
 	autoload :DoubleRenderError, "phlex/errors/double_render_error"
 	autoload :Elements, "phlex/elements"
 	autoload :Error, "phlex/error"

--- a/lib/phlex/deferred_render.rb
+++ b/lib/phlex/deferred_render.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Phlex::DeferredRender
-	# This module doesn't do anything. Phlex::HTML#call checks for its inclusion in the ancestry instead.
-end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -90,24 +90,23 @@ class Phlex::SGML
 		end
 
 		@_context.around_render do
+			before_template(&block)
+
 			around_template do
 				if block
-					if Phlex::DeferredRender === self
-						vanish(self, &block)
-						view_template
-					else
-						view_template do |*args|
-							if args.length > 0
-								__yield_content_with_args__(*args, &block)
-							else
-								__yield_content__(&block)
-							end
+					view_template do |*args|
+						if args.length > 0
+							__yield_content_with_args__(*args, &block)
+						else
+							__yield_content__(&block)
 						end
 					end
 				else
 					view_template
 				end
 			end
+
+			after_template
 		end
 
 		unless parent
@@ -235,7 +234,11 @@ class Phlex::SGML
 	def vanish(*args)
 		return unless block_given?
 
-		@_context.capturing_into(Phlex::BlackHole) { yield(*args) }
+		if args.length > 0
+			@_context.capturing_into(Phlex::BlackHole) { yield(*args) }
+		else
+			@_context.capturing_into(Phlex::BlackHole) { yield(self) }
+		end
 
 		nil
 	end
@@ -252,10 +255,7 @@ class Phlex::SGML
 	end
 
 	def around_template
-		before_template
 		yield
-		after_template
-
 		nil
 	end
 

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -106,7 +106,7 @@ class Phlex::SGML
 				end
 			end
 
-			after_template
+			after_template(&block)
 		end
 
 		unless parent

--- a/quickdraw/sgml/callbacks.test.rb
+++ b/quickdraw/sgml/callbacks.test.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class Example < Phlex::HTML
-	def around_template
+	def before_template
 		i { "1" }
+	end
+
+	def around_template
+		i { "2" }
 
 		super do
 			i { "3" }
@@ -10,15 +14,11 @@ class Example < Phlex::HTML
 			i { "5" }
 		end
 
-		i { "7" }
-	end
-
-	def before_template
-		i { "2" }
+		i { "6" }
 	end
 
 	def after_template
-		i { "6" }
+		i { "7" }
 	end
 
 	def view_template


### PR DESCRIPTION
This abstraction is too confusing. If you understand the concept, you can still use it by yielding early.

```ruby
def view_template
  vanish { yield }

  # ...
end
```

This PR also changes the callbacks so `before_template` is given the block and can yield it.

```ruby
def before_template
  vanish { yield }
end
```

You can put this in a module called `DeferredRender` if you want. It’s up to you.