### PR TITLE
Allow recursively nested tokens in attributes

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -502,6 +502,14 @@ class Phlex::SGML
 				else
 					buffer << token.to_s
 				end
+			when Array
+				if token.length > 0
+					if i > 0
+						buffer << " " << __nested_tokens__(token)
+					else
+						buffer << __nested_tokens__(token)
+					end
+				end
 			when nil
 				# Do nothing
 			else

--- a/quickdraw/sgml/attributes.test.rb
+++ b/quickdraw/sgml/attributes.test.rb
@@ -258,6 +258,24 @@ test "_, Array(Phlex::SGML::SafeObject)" do
 	) == %(<div attribute="Hello"></div>)
 end
 
+test "_, Array(String | Array)" do
+	expect(
+		phlex { div(attribute: ["hello", ["world"]]) },
+	) == %(<div attribute="hello world"></div>)
+end
+
+test "_, Array(Array | String)" do
+	expect(
+		phlex { div(attribute: [["hello"], "world"]) },
+	) == %(<div attribute="hello world"></div>)
+end
+
+test "_, Array(String | EmptyArray)" do
+	expect(
+		phlex { div(attribute: ["hello", []]) },
+	) == %(<div attribute="hello"></div>)
+end
+
 test "_, Array(*invalid*)" do
 	expect {
 		phlex { div(attribute: [Object.new]) }


### PR DESCRIPTION
If you have a component that you want to take in an attribute of a token list, like `class`, and you want your interface to be polymorphic like an element method's attributes would be, you currently need to type check the provided attribute and handle it manually.

```rb
class Card < Phlex::HTML
  def initialize(class:)
    @class = grab(class:)
  end

  def view_template
    div(class: ["component-classes", @class])
  end
end
```

Before this PR, the above example will break if the person using the Card component tries to supply an array of classes, because `Array` is not a valid token type for `__nested_tokens__`.

```rb
render Card.new(class: "fine") # => <div class="component-classes fine"></div>
render Card.new(class: ["not-fine"]) # => 💥 
```

Now if an array is passed, it will also have `__nested_tokens__` called on it.

```rb
render Card.new(class: ["now-fine"]) # => <div class="component-classes now-fine"></div>
```