### PR TITLE
Expose `styles` method

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -267,6 +267,10 @@ class Phlex::SGML
 		nil
 	end
 
+	def styles(value)
+		__styles__(value).gsub('"', "&quot;")
+	end
+
 	def __yield_content__
 		return unless block_given?
 
@@ -372,21 +376,21 @@ class Phlex::SGML
 			when Hash
 				case k
 				when :style
-					__styles__(v).gsub('"', "&quot;")
+					styles(v)
 				else
 					__nested_attributes__(v, "#{name}-", buffer)
 				end
 			when Array
 				case k
 				when :style
-					__styles__(v).gsub('"', "&quot;")
+					styles(v)
 				else
 					__nested_tokens__(v)
 				end
 			when Set
 				case k
 				when :style
-					__styles__(v).gsub('"', "&quot;")
+					styles(v)
 				else
 					__nested_tokens__(v.to_a)
 				end


### PR DESCRIPTION
What do you think about exposing `styles` method? I was building some style for my form builder (generating HTML via Rails), and I could not use `style: { color: "white" }` because it isn't processed by Phlex.
```ruby
def view_template
  form_with(...) do |form|
    form.submit style: { background_color: "white", color: "red" }
    # => <input ... style="background_color white color red">
  end
end
```

So I thought using the same method Phlex uses but I noticed the `__styles__` method is "internal" and generates unsafe code. I think it would be nice to expose it to users. I'm not sure about the method name, and I think we need at least one test to ensure this method is exposed.

With this change, we can do something like:
```ruby
form.submit style: styles({ background_color: "white", color: "red" })
# => <input ... style="background_color: white; color: red">
```