### PR TITLE
Allow context to be set via `call`

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -2,18 +2,19 @@
 
 # @api private
 class Phlex::Context
-	def initialize(user_context = {})
+	def initialize(user_context: {}, view_context: nil)
 		@buffer = +""
 		@capturing = false
 		@user_context = user_context
 		@fragments = nil
 		@in_target_fragment = false
 		@halt_signal = nil
+		@view_context = view_context
 	end
 
 	attr_accessor :buffer, :capturing, :user_context, :in_target_fragment
 
-	attr_reader :fragments
+	attr_reader :fragments, :view_context
 
 	def target_fragments(fragments)
 		@fragments = fragments.to_h { |it| [it, true] }


### PR DESCRIPTION
This PR is doing more than one thing 🙈

If you want me to split this up, let me know. But in addition to allowing `context` to be passed via `call`, I've also moved where `view_context` is stored. It's now inside of the `Phlex::Context` instead of in an ivar of SGML.

I think that ultimately, `view_context` as a concept can be fully removed from Phlex, and only defined in phlex-rails which is the only place it gets used. But as I went down that path the changes got more and more complicated. `phlex-rails` then needs to redefine `call`, which means it needs to be tightly coupled to `phlex`'s definition of `call`... it got messy.

Let me know what you think, and if you want me to leave `@_view_context` alone, that's fine too. I'll open a sibling PR over on phlex-rails to coincide with this change.