### PR TITLE
Add fiber isolation

### DIFF
--- a/lib/phlex/kit.rb
+++ b/lib/phlex/kit.rb
@@ -60,7 +60,8 @@ module Phlex::Kit
 			end
 
 			define_singleton_method(name) do |*args, **kwargs, &block|
-				if (component = Thread.current[:__phlex_component__])
+				component, fiber_id = Thread.current[:__phlex_component__]
+				if (component && fiber_id == Fiber.current.object_id)
 					component.instance_exec do
 						constant = me.const_get(name)
 						render(constant.new(*args, **kwargs), &block)

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -70,7 +70,7 @@ class Phlex::SGML
 
 		return "" unless render?
 
-		Thread.current[:__phlex_component__] = self
+		Thread.current[:__phlex_component__] = [self, Fiber.current.object_id]
 
 		phlex_context.around_render do
 			before_template(&block)
@@ -96,7 +96,7 @@ class Phlex::SGML
 			buffer << phlex_context.buffer
 		end
 	ensure
-		Thread.current[:__phlex_component__] = parent
+		Thread.current[:__phlex_component__] = [parent, Fiber.current.object_id]
 	end
 
 	protected def __context__ = @_context


### PR DESCRIPTION
Thread locals are not Fiber-isolated and neither are Fiber locals Thread-isolated. The approach taken in this PR is to use a Thread local, storing the current fiber ID with the value. Then we can check the ids match when reading.