### PR TITLE
Show warning if `view_template` method is not defined on Phlex class

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -47,6 +47,8 @@ class Phlex::SGML
 	def view_template
 		if block_given?
 			yield
+		else
+			plain "Phlex Warning: Your `#{self.class.name}` class doesn't define a `view_template` method. If you are upgrading to Phlex 2.x make sure to rename your `template` method to `view_template`. See: https://beta.phlex.fun/guides/v2-upgrade.html"
 		end
 	end
 

--- a/quickdraw/sgml.test.rb
+++ b/quickdraw/sgml.test.rb
@@ -1,8 +1,32 @@
 # frozen_string_literal: true
 
 test "components render with a default blank view_template" do
-	component = Class.new(Phlex::HTML)
+	component = Class.new(Phlex::HTML) do
+		def view_template
+		end
+	end
+
 	expect(component.new.call) == ""
+end
+
+test "components with old `template` method render warning" do
+	component = Class.new(Phlex::HTML) do
+		def template
+			span "old template"
+		end
+	end
+
+	expect(component.new.call) == Phlex::Escape.html_escape(
+		%(Phlex Warning: Your `#{component.name}` class doesn't define a `view_template` method. If you are upgrading to Phlex 2.x make sure to rename your `template` method to `view_template`. See: https://beta.phlex.fun/guides/v2-upgrade.html)
+	)
+end
+
+test "components with no `view_template` method render warning" do
+	component = Class.new(Phlex::HTML)
+
+	expect(component.new.call) == Phlex::Escape.html_escape(
+		%(Phlex Warning: Your `#{component.name}` class doesn't define a `view_template` method. If you are upgrading to Phlex 2.x make sure to rename your `template` method to `view_template`. See: https://beta.phlex.fun/guides/v2-upgrade.html)
+	)
 end
 
 test "can't render a component more than once" do


### PR DESCRIPTION
I just upgraded  Phlex to the latest 2.x rc in a Rails app and after bumping the `phlex` and `phlex-rails` versions the app would boot, the pages would render but all components would just render out as empty strings, since none of the components defined the new `view_template` method.

This pull request adds a warning to the rendered component output so that you know what's going on when you are upgrading.

Feel free to close this pull request if you feel like there's not place for this in Phlex.