### PR TITLE
Fragment caching

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -28,7 +28,6 @@ module Phlex
 
 	CACHED_FILES = Set.new
 	DEPLOY_KEY = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-	CACHE_STORE = NullCacheStore.new
 
 	def self.__expand_attribute_cache__(file_path)
 		unless CACHED_FILES.include?(file_path)

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -17,17 +17,16 @@ module Phlex
 	autoload :Helpers, "phlex/helpers"
 	autoload :Kit, "phlex/kit"
 	autoload :NameError, "phlex/errors/name_error"
-	autoload :NullCacheStore, "phlex/null_cache_store"
 	autoload :SGML, "phlex/sgml"
 	autoload :SVG, "phlex/svg"
 	autoload :Vanish, "phlex/vanish"
 
 	Escape = ERB::Escape
-	ATTRIBUTE_CACHE = FIFO.new
 	Null = Object.new.freeze
 
-	CACHED_FILES = Set.new
 	DEPLOY_KEY = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+	CACHED_FILES = Set.new
+	ATTRIBUTE_CACHE = FIFO.new
 
 	def self.__expand_attribute_cache__(file_path)
 		unless CACHED_FILES.include?(file_path)

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -5,7 +5,6 @@ require "set"
 
 module Phlex
 	autoload :ArgumentError, "phlex/errors/argument_error"
-	autoload :Vanish, "phlex/vanish"
 	autoload :CSV, "phlex/csv"
 	autoload :Callable, "phlex/callable"
 	autoload :Context, "phlex/context"
@@ -13,18 +12,23 @@ module Phlex
 	autoload :Elements, "phlex/elements"
 	autoload :Error, "phlex/error"
 	autoload :FIFO, "phlex/fifo"
+	autoload :FIFOCacheStore, "phlex/fifo_cache_store"
 	autoload :HTML, "phlex/html"
 	autoload :Helpers, "phlex/helpers"
 	autoload :Kit, "phlex/kit"
 	autoload :NameError, "phlex/errors/name_error"
+	autoload :NullCacheStore, "phlex/null_cache_store"
 	autoload :SGML, "phlex/sgml"
 	autoload :SVG, "phlex/svg"
+	autoload :Vanish, "phlex/vanish"
 
 	Escape = ERB::Escape
 	ATTRIBUTE_CACHE = FIFO.new
 	Null = Object.new.freeze
 
 	CACHED_FILES = Set.new
+	DEPLOY_KEY = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+	CACHE_STORE = NullCacheStore.new
 
 	def self.__expand_attribute_cache__(file_path)
 		unless CACHED_FILES.include?(file_path)

--- a/lib/phlex/fifo.rb
+++ b/lib/phlex/fifo.rb
@@ -7,7 +7,7 @@ class Phlex::FIFO
 		@max_bytesize = max_bytesize
 		@max_value_bytesize = max_value_bytesize
 		@bytesize = 0
-		@mutex = Mutex.new
+		@mutex = Monitor.new
 	end
 
 	attr_reader :bytesize, :max_bytesize

--- a/lib/phlex/fifo_cache_store.rb
+++ b/lib/phlex/fifo_cache_store.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Phlex::FIFOCacheStore
+	def initialize(max_bytesize: 2 ** 20)
+		@fifo = Phlex::FIFO.new(
+			max_bytesize:,
+			max_value_bytesize: max_bytesize
+		)
+	end
+
+	def fetch(key)
+		fifo = @fifo
+		key = map_key(key)
+
+		if (result = fifo[key])
+			result
+		else
+			result = yield
+			fifo[key] = result
+			result
+		end
+	end
+
+	def map_key(value)
+		case value
+		when Array
+			value.map { |it| map_key(it) }
+		when Hash
+			value.to_h { |k, v| [map_key(k), map_key(v)].freeze }
+		when String, Symbol, Integer, Float, Time, true, false, nil
+			value
+		else
+			if value.respond_to?(:cache_key)
+				map_key(value.cache_key)
+			else
+				raise ArgumentError.new("Cannot cache #{value.class}")
+			end
+		end
+	end
+end

--- a/lib/phlex/null_cache_store.rb
+++ b/lib/phlex/null_cache_store.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class Phlex::NullCacheStore
+module Phlex::NullCacheStore
+	extend self
+
 	def fetch(key)
 		yield
 	end

--- a/lib/phlex/null_cache_store.rb
+++ b/lib/phlex/null_cache_store.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Phlex::NullCacheStore
+	def fetch(key)
+		yield
+	end
+end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -223,6 +223,19 @@ class Phlex::SGML
 		nil
 	end
 
+	def cache(*keys, **, &)
+		context = @_context
+		return if context.fragments && !context.in_target_fragment
+
+		context.buffer << cache_store.fetch(
+			[Phlex::DEPLOY_KEY, self.class.name, __method__, keys].freeze, **
+		) { capture(&) }
+	end
+
+	def cache_store
+		Phlex::CACHE_STORE
+	end
+
 	private
 
 	def vanish(*args)

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -240,9 +240,9 @@ class Phlex::SGML
 
 		full_key = [
 			Phlex::DEPLOY_KEY,   # invalidates the key when deploying new code in case of changes
-			self.class.name,     # prevents collissions between classes
-			location.base_label, # prevents collissions between different methods
-			location.lineno,     # prevents collissions between different lines
+			self.class.name,     # prevents collisions between classes
+			location.base_label, # prevents collisions between different methods
+			location.lineno,     # prevents collisions between different lines
 			cache_key,           # allows for custom cache keys
 		].freeze
 

--- a/quickdraw/fifo_cache_store.test.rb
+++ b/quickdraw/fifo_cache_store.test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+test "fetch caches the yield" do
+	store = Phlex::FIFOCacheStore.new
+	count = 0
+
+	first_read = store.fetch("a") do
+		count += 1
+		"A"
+	end
+
+	assert_equal first_read, "A"
+	assert_equal count, 1
+
+	second_read = store.fetch("a") do
+		failure! { "This block should not have been called." }
+		"B"
+	end
+
+	assert_equal second_read, "A"
+	assert_equal count, 1
+end
+
+test "nested caches do not lead to contention" do
+	store = Phlex::FIFOCacheStore.new
+
+	result = store.fetch("a") do
+		[
+			"A",
+			store.fetch("b") { "B" },
+		].join(", ")
+	end
+
+	assert_equal result, "A, B"
+end
+
+test "caching something other than a string" do
+	store = Phlex::FIFOCacheStore.new
+
+	assert_raises(ArgumentError) do
+		store.fetch("a") { 1 }
+	end
+end


### PR DESCRIPTION
This PR introduces a new helper method to support fragment caching. I’ve been reluctant to add fragment caching because it’s difficult to expire the cache when templates change and I didn’t want to try to build up a static dependency tree between components, partials, etc.

For now, we’re keeping it simple by expiring the cache on each deploy via a deploy key (see below).

**Example:**
```ruby
cache @products do
  @products.each do |product|
    cache product do
      h1 { product.name }
    end
  end
end
```

The `cache` method will take user cache keys and combine them with built-in supplemental keys to cache the captured content against. `cache` will call `cache_store`, which must return a Phlex cache store.

## Supplemental keys

The `cache` method supplements your cache keys with the following:

1. `Phlex::DEPLOY_KEY` — the time that the app was booted and Phlex was loaded.
5. The name of the class where the caching is taking place. This prevents collisions between classes.
6. The name of the method where the caching is taking place. This prevents collisions between different methods in the same class.
7. The line number where the `cache` method is called. This prevents collisions between different lines, especially when no custom cache keys are provided.

## Low level caching

The `low_level_cache` method requires a cache key from you and you control the entire cache key.

## Cache store interface

Cache stores are objects that respond to `fetch(key, &content)`. This method must return the result of `yield` or a previously cached result of `yield`. This method may raise if the result of `yield` is not a string or if the key is not valid.

It’s up to you what keys are valid, but note that Phlex itself uses arrays, string and integers in its keys.

This interface is a subset of Rails’ cache interface, meaning Rails cache interface implements this interface can can be used as a Phlex cache store.

## `FIFOCacheStore`

This PR also introduces a new cache store based on the `Phlex::FIFO`. This is an extremely fast in-memory cache store that evicts keys on a first-in-first-out basis. It can be initialised with a max bytesize.