### PR TITLE
Support nested Kits

### DIFF
--- a/fixtures/components.rb
+++ b/fixtures/components.rb
@@ -5,4 +5,12 @@ module Components
 
 	autoload :SayHi, "components/say_hi"
 	autoload :Article, "components/article"
+
+	module Foo
+		class Bar < Phlex::HTML
+			def view_template
+				h1 { "Bar" }
+			end
+		end
+	end
 end

--- a/quickdraw/kit.test.rb
+++ b/quickdraw/kit.test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "components"
+require "sgml_helper"
+include SGMLHelper
 
 class Example < Phlex::HTML
 	include Components
@@ -18,4 +20,8 @@ end
 
 test "defines methods for its components" do
 	assert_equal Example.new.call, %(<article><h1>Hi Joel</h1><h1>Hi Joel</h1>Inside</article><article><h1>Hi Will</h1>Inside</article>)
+end
+
+test "nested kits" do
+	assert_equal_html phlex { Components::Foo::Bar() }, "<h1>Bar</h1>"
 end


### PR DESCRIPTION
With this change, Kits will now propagate down to nested modules. There is currently no way to disable this behaviour, but if anyone needs that, the plan is to introduce `BasicKit` which will not propagate.