### PR TITLE
Add `SGML#fragment` for marking selective rendering blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,6 @@ AllCops:
 # We need to disable this cop because it’s not compatible with TruffleRuby 23.1, which still needs a `require "set"`
 Lint/RedundantRequireStatement:
   Enabled: false
+
+Layout/ExtraSpacing:
+  Enabled: false

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -15,6 +15,7 @@ module Phlex
 	autoload :Helpers, "phlex/helpers"
 	autoload :Kit, "phlex/kit"
 	autoload :NameError, "phlex/errors/name_error"
+	autoload :NullCacheStore, "phlex/null_cache_store"
 	autoload :SGML, "phlex/sgml"
 	autoload :SVG, "phlex/svg"
 	autoload :Vanish, "phlex/vanish"

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -8,6 +8,7 @@ class Phlex::Context
 		@user_context = user_context
 		@fragments = nil
 		@fragment_depth = 0
+		@cache_stack = []
 		@halt_signal = nil
 		@view_context = view_context
 	end
@@ -17,7 +18,7 @@ class Phlex::Context
 	attr_reader :fragments, :fragment_depth, :view_context
 
 	def target_fragments(fragments)
-		@fragments = fragments.to_h { |it| [it, true].freeze }
+		@fragments = fragments.to_set
 	end
 
 	def around_render
@@ -29,20 +30,61 @@ class Phlex::Context
 		end
 	end
 
-	def in_target_fragment
+	def should_render?
 		!@fragments || @fragment_depth > 0
 	end
 
-	def begin_target(id)
-		@fragment_depth += 1 if @fragments&.[](id)
+	def begin_fragment(id)
+		@fragment_depth += 1 if @fragments&.include?(id)
+
+		if caching?
+			current_byte_offset = 0                                 		# Start tracking the byte offset of this fragment from the start of the cache buffer
+			@cache_stack.reverse_each do |(cache_buffer, fragment_map)| # We'll iterate deepest to shallowest
+				current_byte_offset += cache_buffer.bytesize		      		# Add the length of the cache buffer to the current byte offset
+				fragment_map[id] = [current_byte_offset, nil, []]     		# Record the byte offset, length, and store a list of the nested fragments
+
+				fragment_map.each do |name, (_offset, length, nested_fragments)| # Iterate over the other fragments
+					next if name == id || length                       						 # Skip if it's the current fragment, or if the fragment has already ended
+					nested_fragments << id                                       	 # Add the current fragment to the list of nested fragments
+				end
+			end
+		end
 	end
 
-	def end_target(id)
-		return unless @fragments&.[](id)
+	def end_fragment(id)
+		if caching?
+			byte_length = nil
+			@cache_stack.reverse_each do |(cache_buffer, fragment_map)|   # We'll iterate deepest to shallowest
+				byte_length ||= cache_buffer.bytesize - fragment_map[id][0] # The byte length is the difference between the current byte offset and the byte offset of the fragment
+				fragment_map[id][1] = byte_length                           # All cache contexts will use the same by
+			end
+		end
+
+		return unless @fragments&.include?(id)
 
 		@fragments.delete(id)
 		@fragment_depth -= 1
 		throw @halt_signal if @fragments.length == 0
+	end
+
+	def record_fragment(id, offset, length, nested_fragments)
+		return unless caching?
+
+		@cache_stack.reverse_each do |(cache_buffer, fragment_map)|
+			offset += cache_buffer.bytesize
+			fragment_map[id] = [offset, length, nested_fragments]
+		end
+	end
+
+	def caching(&)
+		buffer = +""
+		@cache_stack.push([buffer, {}].freeze)
+		capturing_into(buffer, &)
+		@cache_stack.pop
+	end
+
+	def caching?
+		@cache_stack.length > 0
 	end
 
 	def capturing_into(new_buffer)

--- a/lib/phlex/fifo.rb
+++ b/lib/phlex/fifo.rb
@@ -45,4 +45,11 @@ class Phlex::FIFO
 	def size
 		@store.size
 	end
+
+	def clear
+		@mutex.synchronize do
+			@store.clear
+			@bytesize = 0
+		end
+	end
 end

--- a/lib/phlex/fifo_cache_store.rb
+++ b/lib/phlex/fifo_cache_store.rb
@@ -14,16 +14,11 @@ class Phlex::FIFOCacheStore
 		key = map_key(key)
 
 		if (result = fifo[key])
-			result
+			JSON.parse(result)
 		else
 			result = yield
 
-			case result
-			when String
-				fifo[key] = result
-			else
-				raise ArgumentError.new("Invalid cache value: #{result.class}")
-			end
+			fifo[key] = JSON.fast_generate(result)
 
 			result
 		end

--- a/lib/phlex/fifo_cache_store.rb
+++ b/lib/phlex/fifo_cache_store.rb
@@ -29,6 +29,10 @@ class Phlex::FIFOCacheStore
 		end
 	end
 
+	def clear
+		@fifo.clear
+	end
+
 	private
 
 	def map_key(value)

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -10,7 +10,7 @@ class Phlex::HTML < Phlex::SGML
 	# Output an HTML doctype.
 	def doctype
 		context = @_context
-		return unless context.in_target_fragment
+		return unless context.should_render?
 
 		context.buffer << "<!doctype html>"
 		nil

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -10,6 +10,7 @@ class Phlex::HTML < Phlex::SGML
 	# Output an HTML doctype.
 	def doctype
 		context = @_context
+		return unless context.in_target_fragment
 
 		context.buffer << "<!doctype html>"
 		nil

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -56,7 +56,7 @@ class Phlex::SGML
 		proc { |c| c.render(self) }
 	end
 
-	def call(buffer = +"", context: {}, view_context: nil, parent: nil, &block)
+	def call(buffer = +"", context: {}, view_context: nil, parent: nil, fragments: nil, &block)
 		@_buffer = buffer
 		@_context = phlex_context = parent&.__context__ || Phlex::Context.new(user_context: context, view_context:)
 		@_parent = parent
@@ -64,29 +64,35 @@ class Phlex::SGML
 		raise Phlex::DoubleRenderError.new("You can't render a #{self.class.name} more than once.") if @_rendered
 		@_rendered = true
 
+		if fragments
+			phlex_context.target_fragments(fragments)
+		end
+
 		block ||= @_content_block
 
 		return "" unless render?
 
 		Thread.current[:__phlex_component__] = [self, Fiber.current.object_id].freeze
 
-		before_template(&block)
+		phlex_context.around_render do
+			before_template(&block)
 
-		around_template do
-			if block
-				view_template do |*args|
-					if args.length > 0
-						__yield_content_with_args__(*args, &block)
-					else
-						__yield_content__(&block)
+			around_template do
+				if block
+					view_template do |*args|
+						if args.length > 0
+							__yield_content_with_args__(*args, &block)
+						else
+							__yield_content__(&block)
+						end
 					end
+				else
+					view_template
 				end
-			else
-				view_template
 			end
-		end
 
-		after_template(&block)
+			after_template(&block)
+		end
 
 		unless parent
 			buffer << phlex_context.buffer
@@ -113,6 +119,7 @@ class Phlex::SGML
 	# Output a single space character. If a block is given, a space will be output before and after the block.
 	def whitespace(&)
 		context = @_context
+		return unless context.in_target_fragment
 
 		buffer = context.buffer
 
@@ -131,6 +138,7 @@ class Phlex::SGML
 	# [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Comments)
 	def comment(&)
 		context = @_context
+		return unless context.in_target_fragment
 
 		buffer = context.buffer
 
@@ -146,6 +154,7 @@ class Phlex::SGML
 		case content
 		when Phlex::SGML::SafeObject
 			context = @_context
+			return unless context.in_target_fragment
 
 			context.buffer << content.to_s
 		when nil, "" # do nothing
@@ -165,6 +174,13 @@ class Phlex::SGML
 		else
 			@_context.capturing_into(+"") { __yield_content__(&block) }
 		end
+	end
+
+	# Define a named fragment that can be selectively rendered.
+	def fragment(name)
+		@_context.begin_target(name)
+		yield
+		@_context.end_target(name)
 	end
 
 	# Mark the given string as safe for HTML output.
@@ -340,6 +356,7 @@ class Phlex::SGML
 
 	def __implicit_output__(content)
 		context = @_context
+		return true unless context.in_target_fragment
 
 		case content
 		when Phlex::SGML::SafeObject
@@ -364,6 +381,7 @@ class Phlex::SGML
 	# same as __implicit_output__ but escapes even `safe` objects
 	def __text__(content)
 		context = @_context
+		return true unless context.in_target_fragment
 
 		case content
 		when String

--- a/lib/phlex/sgml/elements.rb
+++ b/lib/phlex/sgml/elements.rb
@@ -14,6 +14,11 @@ module Phlex::SGML::Elements
 				buffer = context.buffer
 				block_given = block_given?
 
+				unless context.in_target_fragment
+					yield(self) if block_given
+					return nil
+				end
+
 				if attributes.length > 0 # with attributes
 					if block_given # with content block
 						buffer << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << ">"
@@ -88,6 +93,8 @@ module Phlex::SGML::Elements
 			def #{method_name}(**attributes)
 				context = @_context
 				buffer = context.buffer
+
+				return unless context.in_target_fragment
 
 				if attributes.length > 0 # with attributes
 					buffer << "<#{tag}" << (::Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << ">"

--- a/lib/phlex/sgml/elements.rb
+++ b/lib/phlex/sgml/elements.rb
@@ -14,7 +14,7 @@ module Phlex::SGML::Elements
 				buffer = context.buffer
 				block_given = block_given?
 
-				unless context.in_target_fragment
+				unless context.should_render?
 					yield(self) if block_given
 					return nil
 				end
@@ -94,7 +94,7 @@ module Phlex::SGML::Elements
 				context = @_context
 				buffer = context.buffer
 
-				return unless context.in_target_fragment
+				return unless context.should_render?
 
 				if attributes.length > 0 # with attributes
 					buffer << "<#{tag}" << (::Phlex::ATTRIBUTE_CACHE[attributes] ||= __attributes__(attributes)) << ">"

--- a/quickdraw/attribute_cache_expansion.test.rb
+++ b/quickdraw/attribute_cache_expansion.test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+test "using a component without a source location" do
+	refute_raises do
+		# Intentionally not passing a source location here.
+		eval <<~RUBY
+			class Example < Phlex::HTML
+				def view_template
+				end
+			end
+		RUBY
+	end
+end

--- a/quickdraw/caching.test.rb
+++ b/quickdraw/caching.test.rb
@@ -1,13 +1,27 @@
 # frozen_string_literal: true
 
-test "using a component without a source location" do
-	refute_raises do
-		# Intentionally not passing a source location here.
-		eval <<~RUBY
-			class Example < Phlex::HTML
-				def view_template
-				end
-			end
-		RUBY
+CacheStore = Phlex::FIFOCacheStore.new
+
+class CacheTest < Phlex::HTML
+	def cache_store = CacheStore
+
+	def initialize(execution_watcher)
+		@execution_watcher = execution_watcher
 	end
+
+	def view_template
+		cache do
+			@execution_watcher.call
+			"OK"
+		end
+	end
+end
+
+test "caching a block only executes once" do
+	run_count = 0
+	monitor = -> { run_count += 1 }
+	CacheTest.new(monitor).call
+	assert_equal run_count, 1
+	CacheTest.new(monitor).call
+	assert_equal run_count, 1
 end

--- a/quickdraw/fifo_cache_store.test.rb
+++ b/quickdraw/fifo_cache_store.test.rb
@@ -33,11 +33,3 @@ test "nested caches do not lead to contention" do
 
 	assert_equal result, "A, B"
 end
-
-test "caching something other than a string" do
-	store = Phlex::FIFOCacheStore.new
-
-	assert_raises(ArgumentError) do
-		store.fetch("a") { 1 }
-	end
-end

--- a/quickdraw/selective_rendering_from_cache.test.rb
+++ b/quickdraw/selective_rendering_from_cache.test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class CacheTest < Phlex::HTML
+	attr_reader :cache_store
+
+	def initialize(page_id, cache_store:)
+		@page_id = page_id
+		@cache_store = cache_store
+	end
+
+	def view_template
+		cache(@page_id) do
+			h1 { "Page #{@page_id}" }
+			fragment("outer") do
+				div(id: "page") do
+					cache do
+						section do
+							fragment("list") do
+								ul do
+									fragment("foo") { li { 1 } }
+									li { 2 }
+									li { 3 }
+								end
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+end
+
+test "rendering a component with caches and fragments" do
+	cache_store = Phlex::FIFOCacheStore.new
+	output = CacheTest.new(1, cache_store:).call
+	assert_equal_html output, "<h1>Page 1</h1><div id=\"page\"><section><ul><li>1</li><li>2</li><li>3</li></ul></section></div>"
+
+	output = CacheTest.new(1, cache_store:).call
+	assert_equal_html output, "<h1>Page 1</h1><div id=\"page\"><section><ul><li>1</li><li>2</li><li>3</li></ul></section></div>"
+end
+
+test "rendering a component with caches and fragments" do
+	cache_store = Phlex::FIFOCacheStore.new
+	output = CacheTest.new(1, cache_store:).call
+	assert_equal_html output, "<h1>Page 1</h1><div id=\"page\"><section><ul><li>1</li><li>2</li><li>3</li></ul></section></div>"
+
+	output = CacheTest.new(2, cache_store:).call
+	assert_equal_html output, "<h1>Page 2</h1><div id=\"page\"><section><ul><li>1</li><li>2</li><li>3</li></ul></section></div>"
+end
+
+test "rendering a specific fragment from within a cache" do
+	cache_store = Phlex::FIFOCacheStore.new
+	2.times do
+		output = CacheTest.new(2, cache_store:).call(fragments: ["list"])
+		assert_equal_html output, "<ul><li>1</li><li>2</li><li>3</li></ul>"
+	end
+end
+
+test "rendering a nested fragment from within a cache" do
+	cache_store = Phlex::FIFOCacheStore.new
+	output = CacheTest.new(1, cache_store:).call(fragments: ["foo"])
+	assert_equal_html output, "<li>1</li>"
+end
+
+test "rendering multiple fragments from within a cache" do
+	cache_store = Phlex::FIFOCacheStore.new
+	output = CacheTest.new(1, cache_store:).call(fragments: ["list", "foo"])
+	assert_equal_html output, "<ul><li>1</li><li>2</li><li>3</li></ul>"
+end
+
+test "rendering multiple fragments out of order from within a cache" do
+	cache_store = Phlex::FIFOCacheStore.new
+	output = CacheTest.new(1, cache_store:).call(fragments: ["foo", "list"])
+	assert_equal_html output, "<ul><li>1</li><li>2</li><li>3</li></ul>"
+end
+
+test "cache contains full value if initially rendered as a fragment" do
+	cache_store = Phlex::FIFOCacheStore.new
+	output = CacheTest.new(1, cache_store:).call(fragments: ["foo"])
+	assert_equal_html output, "<li>1</li>"
+
+	output = CacheTest.new(1, cache_store:).call
+	assert_equal_html output, "<h1>Page 1</h1><div id=\"page\"><section><ul><li>1</li><li>2</li><li>3</li></ul></section></div>"
+end
+
+test "fetching a nested fragment from a cached value" do
+	cache_store = Phlex::FIFOCacheStore.new
+	CacheTest.new(1, cache_store:).call # Cache the outer cache for key = 1, and the inner cache for all other keys
+	output = CacheTest.new(2, cache_store:).call(fragments: ["foo"])
+	assert_equal_html output, "<li>1</li>"
+end

--- a/quickdraw/sgml/selective_rendering.test.rb
+++ b/quickdraw/sgml/selective_rendering.test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+class ExampleComponent < Phlex::HTML
+	def view_template(&)
+		div(&)
+	end
+end
+
+class StandardElementExample < Phlex::HTML
+	def initialize(execution_checker = -> {})
+		@execution_checker = execution_checker
+	end
+
+	def view_template
+		doctype
+		div {
+			comment { h1(id: "target") }
+			h1 { "Before" }
+			img(src: "before.jpg")
+			render ExampleComponent.new { "Should not render" }
+			whitespace
+			comment { "This is a comment" }
+			fragment("target") do
+				h1(id: "target") {
+					plain "Hello"
+					strong { "World" }
+					img(src: "image.jpg")
+				}
+			end
+			@execution_checker.call
+			strong { "Here" }
+			fragment("image") do
+				img(id: "image", src: "after.jpg")
+			end
+			h1(id: "target") { "After" }
+		}
+	end
+end
+
+class VoidElementExample < Phlex::HTML
+	def view_template
+		doctype
+		div {
+			comment { h1(id: "target") }
+			h1 { "Before" }
+			img(src: "before.jpg")
+			whitespace
+			comment { "This is a comment" }
+			h1 {
+				plain "Hello"
+				strong { "World" }
+				fragment("target") do
+					img(id: "target", src: "image.jpg")
+				end
+			}
+			img(src: "after.jpg")
+			h1(id: "target") { "After" }
+		}
+	end
+end
+
+class WithCaptureBlock < Phlex::HTML
+	def view_template
+		h1(id: "before") { "Before" }
+		fragment("around") do
+			div(id: "around") do
+				capture do
+					fragment("inside") do
+						h1(id: "inside") { "Inside" }
+					end
+				end
+			end
+		end
+		fragment("after") do
+			h1(id: "after") { "After" }
+		end
+	end
+end
+
+test "renders the just the target fragment" do
+	output = StandardElementExample.new.call(fragments: ["target"])
+	assert_equal_html output, %(<h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1>)
+end
+
+test "works with void elements" do
+	output = VoidElementExample.new.call(fragments: ["target"])
+	assert_equal_html output, %(<img id="target" src="image.jpg">)
+end
+
+test "supports multiple fragments" do
+	output = StandardElementExample.new.call(fragments: ["target", "image"])
+	assert_equal_html output, %(<h1 id="target">Hello<strong>World</strong><img src="image.jpg"></h1><img id="image" src="after.jpg">)
+end
+
+test "halts early after all fragments are found" do
+	called = false
+	checker = -> { called = true }
+	StandardElementExample.new(checker).call(fragments: ["target"])
+
+	refute called
+end
+
+test "with a capture block doesn't render the capture block" do
+	output = WithCaptureBlock.new.call(fragments: ["after"])
+	assert_equal_html output, %(<h1 id="after">After</h1>)
+end
+
+test "with a capture block renders the capture block when selected" do
+	output = WithCaptureBlock.new.call(fragments: ["around"])
+	assert_equal_html output, %(<div id="around">&lt;h1 id=&quot;inside&quot;&gt;Inside&lt;/h1&gt;</div>)
+end
+
+test "with a capture block doesn't select from the capture block" do
+	output = WithCaptureBlock.new.call(fragments: ["inside"])
+	assert_equal_html output, ""
+end


### PR DESCRIPTION
- [x] Implement `SGML#fragment` method
- [x] Support fragments inside of a cached block