### PR TITLE
Restore safe values should be raw

### DIFF
--- a/lib/phlex/sgml/elements.rb
+++ b/lib/phlex/sgml/elements.rb
@@ -27,14 +27,14 @@ module Phlex::SGML::Elements
 						content = yield(self)
 						if original_length == buffer.bytesize
 							case content
-							when nil
-								nil
+							when ::Phlex::SGML::SafeObject
+								buffer << content.to_s
 							when String
 								buffer << ::Phlex::Escape.html_escape(content)
 							when Symbol
 								buffer << ::Phlex::Escape.html_escape(content.name)
-							when ::Phlex::SGML::SafeObject
-								buffer << content.to_s
+							when nil
+								nil
 							else
 								if (formatted_object = format_object(content))
 									buffer << ::Phlex::Escape.html_escape(formatted_object)
@@ -54,14 +54,14 @@ module Phlex::SGML::Elements
 						content = yield(self)
 						if original_length == buffer.bytesize
 							case content
-							when nil
-								nil
+							when ::Phlex::SGML::SafeObject
+								buffer << content.to_s
 							when String
 								buffer << ::Phlex::Escape.html_escape(content)
 							when Symbol
 								buffer << ::Phlex::Escape.html_escape(content.name)
-							when ::Phlex::SGML::SafeObject
-								buffer << content.to_s
+							when nil
+								nil
 							else
 								if (formatted_object = format_object(content))
 									buffer << ::Phlex::Escape.html_escape(formatted_object)


### PR DESCRIPTION
https://github.com/phlex-ruby/phlex/pull/792 added this feature, but https://github.com/phlex-ruby/phlex/pull/846 removed it. This restores the ability to render safe content without needing to call `raw`.

Fixes https://github.com/phlex-ruby/phlex/issues/851