### PR TITLE
Allow `Phlex::HTML` and `Phlex::SVG` to be rendered inline without a class

### DIFF
--- a/config/quickdraw.rb
+++ b/config/quickdraw.rb
@@ -21,7 +21,7 @@ Bundler.require :test
 
 require "phlex"
 
-Phlex.eager_load
+# Phlex.eager_load
 
 # Previous content of test helper now starts here
 $LOAD_PATH.unshift(File.expand_path("../fixtures", __dir__))

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -18,6 +18,7 @@ module Phlex
 	autoload :SGML, "phlex/sgml"
 	autoload :SVG, "phlex/svg"
 	autoload :Vanish, "phlex/vanish"
+	autoload :Proxy, "phlex/proxy"
 
 	Escape = ERB::Escape
 	Null = Object.new.freeze
@@ -42,6 +43,14 @@ module Phlex
 				queue << const if Module === const
 			end
 		end
+	end
+
+	def self.html(&block)
+		HTML.new.call(&Proxy.inliner(block))
+	end
+
+	def self.svg(&block)
+		SVG.new.call(&Proxy.inliner(block))
 	end
 end
 

--- a/lib/phlex/proxy.rb
+++ b/lib/phlex/proxy.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Phlex::Proxy < BasicObject
+	def self.inliner(block)
+		proc do |component|
+			proxy = new(component, block.binding.receiver)
+			proxy.instance_exec(component, &block)
+		end
+	end
+
+	def initialize(component, receiver)
+		receiver.instance_variables.each do |ivar|
+			value = receiver.instance_variable_get(ivar)
+			__instance_variable_set__(ivar, value)
+		end
+
+		@__component__ = component
+		@__receiver__ = receiver
+	end
+
+	define_method :__instance_variable_set__,
+		::Object.instance_method(:instance_variable_set)
+
+	def respond_to_missing?(name)
+		@__receiver__.respond_to?(name) || @__component__.respond_to?(name)
+	end
+
+	def method_missing(name, ...)
+		if @__receiver__.respond_to?(name)
+			@__receiver__.send(name, ...)
+		elsif @__component__.respond_to?(name)
+			@__component__.send(name, ...)
+		else
+			# We want the receiver to raise the error.
+			@__receiver__.send(name, ...)
+		end
+	end
+
+	# (In Rails)
+	# def method_missing(*, **, &)
+	# 	output = super(*, **) { @__component__.capture(&) }
+
+	# 	case output
+	# 	when ActiveSupport::SafeBuffer
+	# 		@__component__.raw(output)
+	# 	else
+	# 		output
+	# 	end
+	# end
+end

--- a/quickdraw/inline.test.rb
+++ b/quickdraw/inline.test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+test "inline html with no yield" do
+	output = Phlex.html do
+		h1 { "Hi" }
+	end
+
+	assert_equal_html output, <<~HTML.strip
+		<h1>Hi</h1>
+	HTML
+end
+
+class Foo
+	def self.woo = "woo"
+end
+
+def tag
+	"tag"
+end
+
+test "inline html with a yield param" do
+	@foo = "Hi"
+
+	output = Phlex.html do |tag|
+		# self here is Phlex but pretending to be the outer self
+		h1 { @foo }
+		h1 { tag.h2 { "#{h2}#{self.tag}" } }
+	end
+
+	assert_equal_html output, <<~HTML.strip
+		<h1>Hi</h1><h1><h2>2tag</h2></h1>
+	HTML
+end
+
+def foo = 1
+def h2 = 2


### PR DESCRIPTION
It's quite common in Rails' View Helpers to implement `content_tag` or `tag.div` calls and chain them using `+`, `concat`, or `safe_content`.

Since the Phlex DSL is kinda expressive in that sense we can expose `Phlex.html` and `Phlex.svg` to inline render HTML/SVGs to a String without having the need to create a class for it, making this ideal for using Phlex in regular Rails View Helpers.

Here are some examples on how you might be able to refactor this using `Phlex.html`:

<details>
<summary>
Redmine's <code>ApplicationHelper</code>
</summary>


[[Source]](https://github.com/redmine/redmine/blob/bc90e0670df930b0a4aa8be1e0d887aac45eea0f/app/helpers/application_helper.rb#L856-L867)


**Before:**
```ruby
module ApplicationHelper
  def actions_dropdown(&)
    content = capture(&)
    if content.present?
      trigger =
        content_tag('span', sprite_icon('3-bullets', l(:button_actions)), :class => 'icon-only icon-actions',
                    :title => l(:button_actions))
      trigger = content_tag('span', trigger, :class => 'drdn-trigger')
      content = content_tag('div', content, :class => 'drdn-items')
      content = content_tag('div', content, :class => 'drdn-content')
      content_tag('span', trigger + content, :class => 'drdn')
    end
  end
end
```

**After:**
```ruby
module ApplicationHelper
  def actions_dropdown(&)
    content = capture(&)

    if content.present?
      Phlex.html do
        span(class: 'drdn') do
          span(class: 'drdn-trigger') do
            span(class: 'icon-only icon-actions', title: l(:button_actions)) do
              sprite_icon('3-bullets', l(:button_actions))
            end
          end

          div(class: 'drdn-content') do
            div(class: 'drdn-items') do
              raw(content)
            end
          end
        end
      end
    end
  end
end
```

</details>


<details>
<summary>
GitLab's <code>Tabs</code>
</summary>


[[Source]](https://github.com/gitlabhq/gitlabhq/blob/9bb15d0553a2a66bf9feb5e513ec79c2424c8f1c/spec/frontend/fixtures/tabs.rb#L18-L22)


**Before:**
```ruby
panels = content_tag(:div, class: 'tab-content') do
  content_tag(:div, 'Foo', { id: 'foo', class: 'tab-pane active', data: { testid: 'foo-panel' } }) +
    content_tag(:div, 'Bar', { id: 'bar', class: 'tab-pane', data: { testid: 'bar-panel' } }) +
    content_tag(:div, 'Qux', { id: 'qux', class: 'tab-pane', data: { testid: 'qux-panel' } })
end
```

**After:**

```ruby
Phlex.html do
  div(class: 'tab-content') do
    div(id: 'foo', class: 'tab-pane active', data: { testid: 'foo-panel' }) { 'Foo' }
    div(id: 'bar', class: 'tab-pane', data: { testid: 'bar-panel' } }) { 'Bar' }
    div(id: 'qux', class: 'tab-pane', data: { testid: 'qux-panel' } }) { 'Qux' }
  end
end
```

</details>

<details>
<summary>
GitLab's <code>DiffHelper</code>
</summary>


[[Source]](https://github.com/gitlabhq/gitlabhq/blob/9bb15d0553a2a66bf9feb5e513ec79c2424c8f1c/app/helpers/diff_helper.rb#L91-L101)


**Before:**
```ruby
module DiffHelper
  def diff_nomappinginraw_line(line, first_line_num_class, second_line_num_class, content_line_class)
    css_class = ''
    css_class = 'old' if line.type == 'old-nomappinginraw'
    css_class = 'new' if line.type == 'new-nomappinginraw'

    html = [content_tag(:td, '', class: [*first_line_num_class, css_class])]
    html << content_tag(:td, '', class: [*second_line_num_class, css_class]) if second_line_num_class
    html << content_tag(:td, diff_line_content(line.rich_text), class: [*content_line_class, 'nomappinginraw', css_class])

    html.join.html_safe
  end
end
```

**After:**

```ruby
module DiffHelper
  def diff_nomappinginraw_line(line, first_line_num_class, second_line_num_class, content_line_class)
    css_class = ''
    css_class = 'old' if line.type == 'old-nomappinginraw'
    css_class = 'new' if line.type == 'new-nomappinginraw'

    Phlex.html do
      td(class: [*first_line_num_class, css_class])
      td(class: [*second_line_num_class, css_class]) if second_line_num_class
      td(class: [*content_line_class, 'nomappinginraw', css_class]) do
        raw diff_line_content(line.rich_text)
      end
    end
  end
end
```

</details>
