### PR TITLE
Raise a helpful error if you access `context` before rendering

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -94,7 +94,19 @@ class Phlex::SGML
 	end
 
 	def context
-		@_state.user_context
+		if rendering?
+			@_state.user_context
+		else
+			raise Phlex::ArgumentError.new(<<~MESSAGE)
+				You can’t access the context before the component has started rendering.
+			MESSAGE
+		end
+	end
+
+	# Returns `false` before rendering and `true` once the component has started rendering.
+	# It will not reset back to false after rendering.
+	def rendering?
+		!!@_state
 	end
 
 	# Output plain text.

--- a/quickdraw/context.test.rb
+++ b/quickdraw/context.test.rb
@@ -27,3 +27,13 @@ test "user context passed down" do
 
 	assert_equal_html b.new.call, %(<h1>Hello, World!</h1>)
 end
+
+test "raises an ArgumentError if you access the context before rendering" do
+	component = Phlex::HTML.new
+
+	error = assert_raises(Phlex::ArgumentError) { component.context }
+
+	assert_equal error.message, <<~MESSAGE
+		You can’t access the context before the component has started rendering.
+	MESSAGE
+end


### PR DESCRIPTION
If you access the `context` before rendering, the error message says `nil` doesn’t respond to `user_context`. This PR makes `context` return `nil` instead. Opening as a draft as I want to write a test for this before merging.