### PR TITLE
Add delimiter override option for CSVs

### DIFF
--- a/lib/phlex/csv.rb
+++ b/lib/phlex/csv.rb
@@ -4,8 +4,9 @@ class Phlex::CSV
 	FORMULA_PREFIXES = Set["=", "+", "-", "@", "\t", "\r"].freeze
 	SPACE_CHARACTERS = Set[" ", "\t", "\r"].freeze
 
-	def initialize(collection)
+	def initialize(collection, delimiter: ",")
 		@collection = collection
+		@delimiter = delimiter
 		@_headers = []
 		@_current_row = []
 		@_current_column_index = 0
@@ -44,10 +45,10 @@ class Phlex::CSV
 				view_template(*args, **kwargs)
 
 				if @_first && render_headers?
-					buffer << @_headers.join(",") << "\n"
+					buffer << @_headers.join(@delimiter) << "\n"
 				end
 
-				buffer << @_current_row.join(",") << "\n"
+				buffer << @_current_row.join(@delimiter) << "\n"
 				@_current_column_index = 0
 				@_current_row.clear
 			end

--- a/quickdraw/csv.test.rb
+++ b/quickdraw/csv.test.rb
@@ -46,6 +46,19 @@ test "basic csv" do
 	CSV
 end
 
+test "basic csv with semicolon as delimiter" do
+	products = [
+		Product.new("Apple", 1.00),
+		Product.new(" Banana ", 2.00),
+	]
+
+	assert_equal Example.new(products, delimiter: ";").call, <<~CSV
+		name;price
+		Apple;1.0
+		" Banana ";2.0
+	CSV
+end
+
 test "trim whitespace" do
 	products = [
 		Product.new(" Apple", 1.00),


### PR DESCRIPTION
If you want to render values separated with, say, semicolon, this patch lets you do this:

```ruby
users = User.all

UserExport.new(users, delimiter: ";").call
```

Since the vast majority will use commas, I've set comma as the default keyword argument, so this will still work:

```ruby
users = User.all

UserExport.new(users).call
```

Also added a quickdraw test.

Hope this looks okay! This is my first PR here, so if I'm missing any coding standard, let me know. :)