### PR TITLE
[EXPERIMENTAL] Add support for ERB snippets and sidecar templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :test do
 	gem "selenium-webdriver"
 end
 
+gem "nokogiri"
+
 group :development do
 	gem "rubocop"
 	gem "ruby-lsp"

--- a/config/quickdraw.rb
+++ b/config/quickdraw.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "nokogiri"
+
 if ENV["COVERAGE"] == "true"
 	require "simplecov"
 

--- a/quickdraw/erb.test.rb
+++ b/quickdraw/erb.test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Example < Phlex::HTML
+	def initialize
+		@name = "Joel"
+	end
+
+	erb :view_template, <<~ERB
+		<% card do %>
+			<h1>Hello <%= @name %></h1>
+			<%= greeting %>
+		<% end %>
+	ERB
+
+	erb :say_bye, <<~ERB, locals: %(name:)
+		<h2>Goodbye <%= name %></h2>
+	ERB
+
+	def greeting
+		p { "How do you do?" }
+	end
+
+	def card
+		article do
+			yield
+		end
+		say_bye(name: "Joel")
+	end
+end
+
+test do
+	output = Example.call
+
+	assert_equivalent_html output, <<~HTML
+		<article>
+			<h1>Hello Joel</h1>
+			<p>How do you do?</p>
+		</article>
+		<h2>Goodbye Joel</h2>
+	HTML
+end


### PR DESCRIPTION
This PR adds experimental support for ERB snippets in Phlex components.

```ruby
class Nav < Phlex::HTML
  erb :view_template, <<~ERB
    <nav>
      <% yield %>
    </nav>
  ERB
  
  erb :item, <<~ERB, locals: %(href:)
    <a href="<%= href %>">
      <% yield %>
    </a>
  ERB
end
```

Now this component can be called like this from Phlex.

```ruby
class Example < Phlex::HTML
  def view_template
    Nav do |n|
      n.item(href: "/") { "Home" }
    end
  end
end
```

Or from ERB in Phlex

```ruby
class Example < Phlex::HTML
  erb :view_template, <<~ERB
    <% Nav do |n| %>
      <% n.item(href: "/") do %>
        Home
      <% end %>
    <% end %>
  ERB
end
```

## What is a snippet?

Any instance method in a Phlex component is a snippet. You can use the `erb` macro instead of defining a method. If you define a snippet called `view_template`, that will be the main template for the component.

## Inline templates

You can define the ERB templates inline like this

```ruby
erb :snippet_name, <<~ERB
  <h1>Hello</h1>
ERB
```

## External templates

You can define ERB templates that will be loaded from external template files.

```ruby
erb :snippet_name
```

If your component was called `card.rb`, this would read `card/snippet_name.html.erb` as your ERB template. There’s a special case for the `view_template` snippet. In this case, if the file `card/view_template.html.erb` can’t be found, it will look for `card.html.erb` next to the original `card.rb`.

### Locals

You can define parameters in a string passed as the third positional argument.

```ruby
erb :view_template, locals: "(req, opt = nil, keyreq:, keyopt: nil)"
```

This string works as if you had used it in your method definition

```ruby
def view_template(req, opt = nil, keyreq:, keyopt: nil)
  #              ^                                    ^
  #              ^------------------------------------^
  #                              here
```

We recommend using `%()` strings because they look more like params

```ruby
erb :view_template, locals: %(req, opt = nil, keyreq:, keyopt: nil)
```