### PR TITLE
Add VERSION to autoloads

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -4,6 +4,8 @@ require "erb"
 require "set"
 
 module Phlex
+	autoload :VERSION, "phlex/version"
+
 	autoload :Kit, "phlex/kit"
 	autoload :FIFO, "phlex/fifo"
 	autoload :Vanish, "phlex/vanish"


### PR DESCRIPTION
Makes `Phlex::VERSION` automatically available, without having to require it manually. 

Re: https://discord.com/channels/1082611227827638303/1082612756676620318/1343897758045573140

```
$ bundle console
>> require "./lib/phlex"
=> false
>> Phlex::VERSION
=> "2.0.2"
```