### PR TITLE
Add support for CDATA sections in SVGs

### DIFF
--- a/browser_tests.rb
+++ b/browser_tests.rb
@@ -105,6 +105,10 @@ class XSSWithStrings < Phlex::HTML
 			File.open("fixtures/xss.txt") do |file|
 				file.each_line do |line|
 					div(class: line) { line }
+					svg do |s|
+						s.cdata(line)
+						s.cdata { line }
+					end
 				end
 			end
 		end

--- a/lib/phlex/svg.rb
+++ b/lib/phlex/svg.rb
@@ -15,6 +15,20 @@ class Phlex::SVG < Phlex::SGML
 		nil
 	end
 
+	def cdata(content = nil, &block)
+		state = @_state
+		return unless state.should_render?
+
+		if !block && String === content
+			state.buffer << "<![CDATA[" << content.gsub("]]>", "]]>]]<![CDATA[") << "]]>"
+		elsif block && nil == content
+			state.buffer << "<![CDATA[" << capture(&block).gsub("]]>", "]]>]]<![CDATA[") << "]]>"
+		else
+
+			raise Phlex::ArgumentError.new("Expected a String or block.")
+		end
+	end
+
 	def tag(name, **attributes, &)
 		state = @_state
 		block_given = block_given?

--- a/quickdraw/svg.test.rb
+++ b/quickdraw/svg.test.rb
@@ -16,3 +16,25 @@ test "content_type" do
 	component = Class.new(Phlex::SVG)
 	assert_equal component.new.content_type, "image/svg+xml"
 end
+
+test "cdata with string" do
+	component = Class.new(Phlex::SVG) do
+		def view_template
+			cdata("Hello, <[[test]]> World!")
+		end
+	end
+
+	assert_equal component.call, %(<![CDATA[Hello, <[[test]]>]]<![CDATA[ World!]]>)
+end
+
+test "cdata with block" do
+	component = Class.new(Phlex::SVG) do
+		def view_template
+			cdata do
+				path(d: "123")
+			end
+		end
+	end
+
+	assert_equal component.call, %(<![CDATA[<path d="123"></path>]]>)
+end


### PR DESCRIPTION
After this, no one can say Phlex is a leaky abstraction for HTML. It will be a 100% airtight abstraction for valid HTML5 structures.

FWIW, I’ve never used `CDATA` sections before and I’ve never heard of anyone else using them.