### PR TITLE
Adds and passes test for blank and nil csv values

### DIFF
--- a/lib/phlex/csv.rb
+++ b/lib/phlex/csv.rb
@@ -168,7 +168,9 @@ class Phlex::CSV
 			value = value.strip
 
 			if escape_csv_injection
-				if FORMULA_PREFIXES_MAP[value.getbyte(0)]
+				if value.empty?
+					buffer << value
+				elsif FORMULA_PREFIXES_MAP[value.getbyte(0)]
 					value.gsub!('"', '""')
 					buffer << '"\'' << value << '"'
 				elsif value.match?(escape_regex)
@@ -184,7 +186,9 @@ class Phlex::CSV
 			if escape_csv_injection
 				first_byte = value.getbyte(0)
 
-				if FORMULA_PREFIXES_MAP[first_byte]
+				if value.empty?
+					buffer << '""'
+				elsif FORMULA_PREFIXES_MAP[first_byte]
 					buffer << '"\'' << value.gsub('"', '""') << '"'
 				elsif value.match?(escape_regex)
 					buffer << '"' << value.gsub('"', '""') << '"'
@@ -194,6 +198,8 @@ class Phlex::CSV
 			else # not escaping CSV injection
 				if value.match?(escape_regex)
 					buffer << '"' << value.gsub('"', '""') << '"'
+				elsif value.empty?
+					buffer << '""'
 				else
 					buffer << value
 				end

--- a/lib/phlex/csv.rb
+++ b/lib/phlex/csv.rb
@@ -196,10 +196,10 @@ class Phlex::CSV
 					buffer << value
 				end
 			else # not escaping CSV injection
-				if value.match?(escape_regex)
-					buffer << '"' << value.gsub('"', '""') << '"'
-				elsif value.empty?
+				if value.empty?
 					buffer << '""'
+				elsif value.match?(escape_regex)
+					buffer << '"' << value.gsub('"', '""') << '"'
 				else
 					buffer << value
 				end

--- a/quickdraw/csv.test.rb
+++ b/quickdraw/csv.test.rb
@@ -15,6 +15,8 @@ products = [
 	Product.new(:strawberry, "Three pounds"),
 	Product.new("=SUM(A1:B1)", "=SUM(A1:B1)"),
 	Product.new("Abc, \"def\"", "Foo\nbar \"baz\""),
+	Product.new("", ""),
+	Product.new(nil, nil),
 ]
 
 test "don’t escape csv injection or trim whitespace" do
@@ -30,6 +32,8 @@ test "don’t escape csv injection or trim whitespace" do
 		strawberry,Three pounds
 		=SUM(A1:B1),=SUM(A1:B1)
 		"Abc, ""def""","Foo\nbar ""baz"""
+		"",""
+		"",""
 	CSV
 end
 
@@ -46,6 +50,8 @@ test "don’t escape csv injection, but do trim whitespace" do
 		strawberry,Three pounds
 		=SUM(A1:B1),=SUM(A1:B1)
 		Abc, "def",Foo\nbar "baz"
+		,
+		,
 	CSV
 end
 
@@ -63,6 +69,8 @@ test "escape csv injection, but don’t trim whitespace" do
 		"'=SUM(A1:B1)","'=SUM(A1:B1)"
 		"Abc, ""def""","Foo
 		bar ""baz"""
+		"",""
+		"",""
 	CSV
 end
 
@@ -80,6 +88,8 @@ test "escape csv injection and trim whitespace" do
 		"'=SUM(A1:B1)","'=SUM(A1:B1)"
 		"Abc, ""def""","Foo
 		bar ""baz"""
+		,
+		,
 	CSV
 end
 
@@ -96,6 +106,8 @@ test "no headers" do
 		=SUM(A1:B1),=SUM(A1:B1)
 		"Abc, ""def""","Foo
 		bar ""baz"""
+		"",""
+		"",""
 	CSV
 end
 
@@ -125,6 +137,8 @@ test "using view_template instead of row_template" do
 		"'=SUM(A1:B1)","'=SUM(A1:B1)"
 		"Abc, ""def""","Foo
 		bar ""baz"""
+		,
+		,
 	CSV
 end
 
@@ -147,6 +161,8 @@ test "with a yielder" do
 		"'=SUM(A1:B1)","'=SUM(A1:B1)"
 		"Abc, ""def""","Foo
 		bar ""baz"""
+		,
+		,
 	CSV
 end
 
@@ -169,6 +185,8 @@ test "with a custom delimiter defined as a method" do
 		"'=SUM(A1:B1)";"'=SUM(A1:B1)"
 		"Abc, ""def""";"Foo
 		bar ""baz"""
+		;
+		;
 	CSV
 end
 
@@ -190,6 +208,8 @@ test "with a custom delimiter passed in as an argument" do
 		"'=SUM(A1:B1)";"'=SUM(A1:B1)"
 		"Abc, ""def""";"Foo
 		bar ""baz"""
+		;
+		;
 	CSV
 end
 


### PR DESCRIPTION
Currently, calling a CSV template with blank or `nil` values fails when looking up the first byte:


```ruby
# lib/phlex/csv.rb

if FORMULA_PREFIXES_MAP[value.getbyte(0)]

# ...

first_byte = value.getbyte(0)
if FORMULA_PREFIXES_MAP[first_byte]
```

Raises a confusing `eval error: no implicit conversion from nil to integer`

This PR adds and passes specs that match the options for stripping whitespace.

Its currently written to do either:

- `""` for blank values if not stripping whitespace, Ruby parses them to `""`
- Nothing when stripping whitespace, Ruby parses them it to `nil`