### PR TITLE
CSV row fan-out

### DIFF
--- a/quickdraw/csv.test.rb
+++ b/quickdraw/csv.test.rb
@@ -138,6 +138,76 @@ test "with a custom around_row" do
 	CSV
 end
 
+test "with an around_row that calls super more than once" do
+	example = Class.new(Phlex::CSV) do
+		def escape_csv_injection? = true
+		def trim_whitespace? = false
+
+		def around_row(item)
+			super(item.name, item.price)
+			super(item.name, item.price)
+		end
+
+		def row_template(name, price)
+			column "Name", name
+			column "Price", price
+		end
+	end
+
+	assert_equal example.new(products).call, <<~CSV
+		Name,Price
+		Apple,1.0
+		Apple,1.0
+		" Banana ",2.0
+		" Banana ",2.0
+		strawberry,Three pounds
+		strawberry,Three pounds
+		"'=SUM(A1:B1)","'=SUM(A1:B1)"
+		"'=SUM(A1:B1)","'=SUM(A1:B1)"
+		"Abc, ""def""","Foo\nbar ""baz"""
+		"Abc, ""def""","Foo\nbar ""baz"""
+		"",""
+		"",""
+		"",""
+		"",""
+	CSV
+end
+
+test "with a yielder that yields more than once" do
+	example = Class.new(Phlex::CSV) do
+		def escape_csv_injection? = true
+		def trim_whitespace? = false
+
+		def yielder(item)
+			yield(item.name, item.price)
+			yield(item.name, item.price)
+		end
+
+		def row_template(name, price)
+			column "Name", name
+			column "Price", price
+		end
+	end
+
+	assert_equal example.new(products).call, <<~CSV
+		Name,Price
+		Apple,1.0
+		Apple,1.0
+		" Banana ",2.0
+		" Banana ",2.0
+		strawberry,Three pounds
+		strawberry,Three pounds
+		"'=SUM(A1:B1)","'=SUM(A1:B1)"
+		"'=SUM(A1:B1)","'=SUM(A1:B1)"
+		"Abc, ""def""","Foo\nbar ""baz"""
+		"Abc, ""def""","Foo\nbar ""baz"""
+		"",""
+		"",""
+		"",""
+		"",""
+	CSV
+end
+
 test "with a custom delimiter defined as a method" do
 	example = Class.new(Phlex::CSV) do
 		define_method(:escape_csv_injection?) { true }


### PR DESCRIPTION
Prior to #866, the `yielder` was able to `yield` multiple times per item in the collection to "fan-out" one item into multiple rows in the CSV. An example of this would be a CSV that iterates over a collection of invoices, but displays each line item of an invoice as its own row.

```rb
class InvoicesCSV < ApplicationCSV
  def around_row(invoice)
    invoice.line_items.each do |line_item|
      super(invoice, line_item)
    end
  end

  def row_template(invoice, line_item)
    column("Invoice Number", invoice.id)
    column("SKU", line_item.sku)
    column("Quantity", line_item.quantity)
  end
end
```

I have not yet performed any benchmarks on this. To get back the old behavior requires adding many more ivar lookups/method calls per row, eliminating a lot of the benefit that was brought about in #866. I attempted to sidestep a lot of that by pulling all the locals into a proc closure, and calling that. I have no idea if this is better/worse/or the same as just doing the ivar lookups/method calls each row. It may be a terrible idea. But it does pass the tests 🎉 