### PR TITLE
Root hash attributes

### DIFF
--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -26,6 +26,10 @@ module Phlex::Helpers
 					[old] + new.to_a
 				in [String, String]
 					"#{old} #{new}"
+				in [_, Hash]
+					{ _: old, **new }
+				in [Hash, _]
+					{ **old, _: new }
 				in [_, nil]
 					old
 				else

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -566,7 +566,7 @@ class Phlex::SGML
 		attributes.each do |k, v|
 			next unless v
 
-			if k == :_
+			if (root_key = (:_ == k))
 				name = ""
 				original_base_name = base_name
 				base_name = base_name.delete_suffix("-")
@@ -603,7 +603,7 @@ class Phlex::SGML
 				raise Phlex::ArgumentError.new("Invalid attribute value #{v.inspect}.")
 			end
 
-			if k == :_
+			if root_key
 				base_name = original_base_name
 			end
 

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -566,14 +566,20 @@ class Phlex::SGML
 		attributes.each do |k, v|
 			next unless v
 
-			name = case k
-				when String then k
-				when Symbol then k.name.tr("_", "-")
-				else raise Phlex::ArgumentError.new("Attribute keys should be Strings or Symbols")
-			end
+			if k == :_
+				name = ""
+				original_base_name = base_name
+				base_name = base_name.delete_suffix("-")
+			else
+				name = case k
+					when String then k
+					when Symbol then k.name.tr("_", "-")
+					else raise Phlex::ArgumentError.new("Attribute keys should be Strings or Symbols")
+				end
 
-			if name.match?(/[<>&"']/)
-				raise Phlex::ArgumentError.new("Unsafe attribute name detected: #{k}.")
+				if name.match?(/[<>&"']/)
+					raise Phlex::ArgumentError.new("Unsafe attribute name detected: #{k}.")
+				end
 			end
 
 			case v
@@ -595,6 +601,10 @@ class Phlex::SGML
 				buffer << " " << base_name << name << '="' << v.to_s.gsub('"', "&quot;") << '"'
 			else
 				raise Phlex::ArgumentError.new("Invalid attribute value #{v.inspect}.")
+			end
+
+			if k == :_
+				base_name = original_base_name
 			end
 
 			buffer

--- a/quickdraw/helpers/mix.test.rb
+++ b/quickdraw/helpers/mix.test.rb
@@ -33,7 +33,7 @@ test "array + hash" do
 		{ data: { controller: "bar" } },
 	)
 
-	assert_equal output, { data: { controller: "bar" } }
+	assert_equal output, { data: { _: ["foo"], controller: "bar" } }
 end
 
 test "array + string" do

--- a/quickdraw/sgml/attributes.test.rb
+++ b/quickdraw/sgml/attributes.test.rb
@@ -272,6 +272,14 @@ test "_, Hash(String, _)" do
 	assert_raises(Phlex::ArgumentError) { phlex { div(attribute: { ">" => "a" }) } }
 end
 
+test "_, Hash(:_, _)" do
+	by_itself = phlex { div(attribute: { _: "world" }) }
+	assert_equal_html by_itself, %(<div attribute="world"></div>)
+
+	with_others = phlex { div(data: { _: "test", controller: "hello" }) }
+	assert_equal_html with_others, %(<div data="test" data-controller="hello"></div>)
+end
+
 test "_, Hash(*invalid*, _)" do
 	assert_raises(Phlex::ArgumentError) { phlex { div(attribute: { Object.new => "a" }) } }
 end


### PR DESCRIPTION
This closes #887 by allowing hash attribute values to set the root attribute using the `:_` key.

```rb
div(data: { _: "root", controller: "copy" })
```

```html
<div data="root" data-controller="copy"></div>
```

It also includes a change to `mix` to allow it to mix scalar values with hash values.