### PR TITLE
Add `<selectedcontent>` element

### DIFF
--- a/lib/phlex/html/standard_elements.rb
+++ b/lib/phlex/html/standard_elements.rb
@@ -472,6 +472,13 @@ module Phlex::HTML::StandardElements
 	# [Spec](https://html.spec.whatwg.org/#the-select-element)
 	register_element def select(**attributes, &content) = nil
 
+	# [EXPERIMENTAL] Outputs a `<selectedcontent>` tag.
+	#
+	# [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/selectedcontent)
+	# [Draft Spec](https://github.com/whatwg/html/pull/10633)
+	# [Can I Use?](https://caniuse.com/mdn-html_elements_selectedcontent)
+	register_element def selectedcontent(**attributes, &content) = nil
+
 	# Outputs a `<slot>` tag.
 	#
 	# [MDN Docs](https://developer.mozilla.org/docs/Web/HTML/Element/slot)


### PR DESCRIPTION
It’s not every day you get to add a new HTML element.

There’s a [good introduction to this element here](https://www.youtube.com/watch?v=MA9WAHEEfGM), though in the video, the element is `<selectedoption>`. It has subsequently been renamed to `<selectedcontent>`.

Closes #888 