### PR TITLE
Require version when loading gem

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -3,6 +3,7 @@
 require "erb"
 require "set"
 require "zeitwerk"
+require "phlex/version"
 
 module Phlex
 	Loader = Zeitwerk::Loader.for_gem.tap do |loader|


### PR DESCRIPTION
Apps and other gems (like lookbook) want to be able to easily tell whether they are working with Phlex v1 or v2, and lookbook is now trying to check `Phlex::VERSION` for that, which is not loaded by default.

Would it make sense to always load that? It seems like other major gems I checked, like sidekiq, do.